### PR TITLE
NPOS-5038: Refactor delegate functions to return the instance of tracker.

### DIFF
--- a/VastClient/VastClient/constants/TrackingError.swift
+++ b/VastClient/VastClient/constants/TrackingError.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public enum TrackingError: Error {
+    case unableToUpdateProgressTrackingComplete
     case unableToUpdateProgress(msg: String)
     case unableToProvideCreativeClickThroughUrls
     case internalError(msg: String)


### PR DESCRIPTION
Some delegate methods are called immediately after the object is initialised, but we need to use the object in reactions to this delegate calls.