### PR TITLE
NPOS-4654: Icons, tracking, fixes

### DIFF
--- a/VastClient.xcworkspace/contents.xcworkspacedata
+++ b/VastClient.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:/Users/janbednar/Developer/ios-vast-client/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/Inline_linear_icons-test.xml">
+   </FileRef>
+   <FileRef
       location = "group:VastClientWrapper/VastClientWrapper.xcodeproj">
    </FileRef>
    <FileRef

--- a/VastClient/VastClient.xcodeproj/project.pbxproj
+++ b/VastClient/VastClient.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		A945EE77219C5C9F0007A079 /* vast3.xsd in Resources */ = {isa = PBXBuildFile; fileRef = A945EE57219C5C9E0007A079 /* vast3.xsd */; };
 		A945EE78219C5C9F0007A079 /* vast4.xsd in Resources */ = {isa = PBXBuildFile; fileRef = A945EE58219C5C9E0007A079 /* vast4.xsd */; };
 		A981D9FB21BEAEF100018FD8 /* Inline_linear_icons-test.xml in Resources */ = {isa = PBXBuildFile; fileRef = A981D9FA21BEAEF100018FD8 /* Inline_linear_icons-test.xml */; };
+		A981D9FD21BEB01800018FD8 /* InlineLinearIcons-test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981D9FC21BEB01800018FD8 /* InlineLinearIcons-test.swift */; };
 		A9A3FFB621BA5B4C008DB5D6 /* TestFullVast4.xml in Resources */ = {isa = PBXBuildFile; fileRef = A9A3FFB521BA5B4C008DB5D6 /* TestFullVast4.xml */; };
 		A9A3FFB821BA5CBE008DB5D6 /* FullVast4-test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A3FFB721BA5CBE008DB5D6 /* FullVast4-test.swift */; };
 		A9A84FEC21A3053200949C4B /* VastParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A84FEB21A3053200949C4B /* VastParser.swift */; };
@@ -218,6 +219,7 @@
 		A945EE57219C5C9E0007A079 /* vast3.xsd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vast3.xsd; sourceTree = "<group>"; };
 		A945EE58219C5C9E0007A079 /* vast4.xsd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vast4.xsd; sourceTree = "<group>"; };
 		A981D9FA21BEAEF100018FD8 /* Inline_linear_icons-test.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "Inline_linear_icons-test.xml"; sourceTree = "<group>"; };
+		A981D9FC21BEB01800018FD8 /* InlineLinearIcons-test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InlineLinearIcons-test.swift"; sourceTree = "<group>"; };
 		A9A3FFB521BA5B4C008DB5D6 /* TestFullVast4.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TestFullVast4.xml; sourceTree = "<group>"; };
 		A9A3FFB721BA5CBE008DB5D6 /* FullVast4-test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullVast4-test.swift"; sourceTree = "<group>"; };
 		A9A84FEB21A3053200949C4B /* VastParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VastParser.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 				A945EE4D219C5C9E0007A079 /* InlineLinearTag-test.swift */,
 				A9A3FFB521BA5B4C008DB5D6 /* TestFullVast4.xml */,
 				A9A3FFB721BA5CBE008DB5D6 /* FullVast4-test.swift */,
+				A981D9FC21BEB01800018FD8 /* InlineLinearIcons-test.swift */,
 			);
 			path = Vast4;
 			sourceTree = "<group>";
@@ -661,6 +664,7 @@
 				A91F507821A432750062198F /* PubadsModel-test.swift in Sources */,
 				A945EE35219C5C990007A079 /* VastXMLParserTests.swift in Sources */,
 				A91F508221A437EB0062198F /* VastXMLParserPubadsWrapperTests.swift in Sources */,
+				A981D9FD21BEB01800018FD8 /* InlineLinearIcons-test.swift in Sources */,
 				A9A3FFB821BA5CBE008DB5D6 /* FullVast4-test.swift in Sources */,
 				A945EE5A219C5C9F0007A079 /* AdVerification-test.swift in Sources */,
 				A945EE69219C5C9F0007A079 /* WrapperTag-test.swift in Sources */,

--- a/VastClient/VastClient.xcodeproj/project.pbxproj
+++ b/VastClient/VastClient.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		A945EE76219C5C9F0007A079 /* Inline_Linear_Tag-test3.xml in Resources */ = {isa = PBXBuildFile; fileRef = A945EE56219C5C9E0007A079 /* Inline_Linear_Tag-test3.xml */; };
 		A945EE77219C5C9F0007A079 /* vast3.xsd in Resources */ = {isa = PBXBuildFile; fileRef = A945EE57219C5C9E0007A079 /* vast3.xsd */; };
 		A945EE78219C5C9F0007A079 /* vast4.xsd in Resources */ = {isa = PBXBuildFile; fileRef = A945EE58219C5C9E0007A079 /* vast4.xsd */; };
+		A981D9FB21BEAEF100018FD8 /* Inline_linear_icons-test.xml in Resources */ = {isa = PBXBuildFile; fileRef = A981D9FA21BEAEF100018FD8 /* Inline_linear_icons-test.xml */; };
 		A9A3FFB621BA5B4C008DB5D6 /* TestFullVast4.xml in Resources */ = {isa = PBXBuildFile; fileRef = A9A3FFB521BA5B4C008DB5D6 /* TestFullVast4.xml */; };
 		A9A3FFB821BA5CBE008DB5D6 /* FullVast4-test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A3FFB721BA5CBE008DB5D6 /* FullVast4-test.swift */; };
 		A9A84FEC21A3053200949C4B /* VastParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A84FEB21A3053200949C4B /* VastParser.swift */; };
@@ -216,6 +217,7 @@
 		A945EE56219C5C9E0007A079 /* Inline_Linear_Tag-test3.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "Inline_Linear_Tag-test3.xml"; sourceTree = "<group>"; };
 		A945EE57219C5C9E0007A079 /* vast3.xsd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vast3.xsd; sourceTree = "<group>"; };
 		A945EE58219C5C9E0007A079 /* vast4.xsd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vast4.xsd; sourceTree = "<group>"; };
+		A981D9FA21BEAEF100018FD8 /* Inline_linear_icons-test.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "Inline_linear_icons-test.xml"; sourceTree = "<group>"; };
 		A9A3FFB521BA5B4C008DB5D6 /* TestFullVast4.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TestFullVast4.xml; sourceTree = "<group>"; };
 		A9A3FFB721BA5CBE008DB5D6 /* FullVast4-test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullVast4-test.swift"; sourceTree = "<group>"; };
 		A9A84FEB21A3053200949C4B /* VastParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VastParser.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 		A945EE37219C5C9E0007A079 /* Vast4 */ = {
 			isa = PBXGroup;
 			children = (
+				A981D9FA21BEAEF100018FD8 /* Inline_linear_icons-test.xml */,
 				A91F507421A432290062198F /* Pubads wrapper */,
 				A945EE38219C5C9E0007A079 /* Category-test.xml */,
 				A945EE39219C5C9E0007A079 /* AdVerification-test.swift */,
@@ -561,6 +564,7 @@
 				A945EE6B219C5C9F0007A079 /* Viewable_Impression-test.xml in Resources */,
 				A945EE65219C5C9F0007A079 /* No_Wrapper_Tag-test.xml in Resources */,
 				A945EE67219C5C9F0007A079 /* Inline_Simple-test.xml in Resources */,
+				A981D9FB21BEAEF100018FD8 /* Inline_linear_icons-test.xml in Resources */,
 				A945EE77219C5C9F0007A079 /* vast3.xsd in Resources */,
 				A91F507E21A432AF0062198F /* Pubads_Wrapper_Model-test.xml in Resources */,
 				A945EE59219C5C9F0007A079 /* Category-test.xml in Resources */,

--- a/VastClient/VastClient/VastTracker.swift
+++ b/VastClient/VastClient/VastTracker.swift
@@ -41,8 +41,8 @@ public class VastTracker {
         self.startTime = startTime
         self.vastModel = vastModel
         self.vastAds = vastModel.ads
-            .filter { supportAdBuffets ? true : $0.sequence > 0 }
-            .sorted(by: { $0.sequence < $1.sequence })
+            .filter { supportAdBuffets ? true : $0.sequence != nil }
+            .sorted(by: { $0.sequence ?? 0 < $1.sequence ?? 0 })
         self.trackingStatus = .tracking
         self.delegate = delegate
 
@@ -71,7 +71,7 @@ public class VastTracker {
 
         if currentTrackingCreative == nil {
             guard let vastAd = vastAds.first,
-                let linearCreative = vastAd.creatives.first?.linear, vastAd.sequence > 0 else {
+                let linearCreative = vastAd.creatives.first?.linear, vastAd.sequence ?? 1 > 0 else {
                     trackingStatus = .complete
                     delegate?.adBreakComplete(vastTracker: self, vastModel: vastModel)
                     return

--- a/VastClient/VastClient/VastTracker.swift
+++ b/VastClient/VastClient/VastTracker.swift
@@ -112,67 +112,75 @@ public class VastTracker {
             creative.callTrackingUrls(progressUrls)
         }
 
-        if playhead < creative.duration {
-            if !creative.trackedStart {
-                creative.trackedStart = true
-
-                let impressions = creative.vastAd.impressions.filter { $0.url != nil }.map { $0.url! }
+        guard playhead < creative.duration else {
+            return
+        }
+        if !creative.trackedStart {
+            creative.trackedStart = true
+            
+            let impressions = creative.vastAd.impressions.filter { $0.url != nil }.map { $0.url! }
+            let trackingUrls = creative.creative.trackingEvents
+                .filter { ($0.type == .creativeView || $0.type == .start) && $0.url != nil }
+                .map { $0.url! }
+            creative.callTrackingUrls(impressions + trackingUrls)
+            delegate?.adStart(vastTracker: self, ad: creative.vastAd)
+        }
+        
+        if playhead > creative.firstQuartile && playhead < creative.midpoint {
+            if !creative.trackedFirstQuartile {
+                creative.trackedFirstQuartile = true
                 let trackingUrls = creative.creative.trackingEvents
-                    .filter { ($0.type == .creativeView || $0.type == .start) && $0.url != nil }
-                    .map { $0.url! }
-                creative.callTrackingUrls(impressions + trackingUrls)
-                delegate?.adStart(vastTracker: self, ad: creative.vastAd)
-            }
-
-            if playhead > creative.firstQuartile && playhead < creative.midpoint {
-                if !creative.trackedFirstQuartile {
-                    creative.trackedFirstQuartile = true
-                    let trackingUrls = creative.creative.trackingEvents
-                        .filter { $0.type == .firstQuartile && $0.url != nil }
-                        .map { $0.url! }
-                    creative.callTrackingUrls(trackingUrls)
-                    delegate?.adFirstQuartile(vastTracker: self, ad: creative.vastAd)
-                }
-            } else if playhead > creative.midpoint && playhead < creative.thirdQuartile {
-                if !creative.trackedMidpoint {
-                    creative.trackedMidpoint = true
-                    let trackingUrls = creative.creative.trackingEvents
-                        .filter { $0.type == .midpoint && $0.url != nil }
-                        .map { $0.url! }
-                    creative.callTrackingUrls(trackingUrls)
-                    delegate?.adMidpoint(vastTracker: self, ad: creative.vastAd)
-                }
-            } else if playhead > creative.thirdQuartile && playhead < creative.duration {
-                if !creative.trackedThirdQuartile {
-                    creative.trackedThirdQuartile = true
-                    let trackingUrls = creative.creative.trackingEvents
-                        .filter { $0.type == .thirdQuartile && $0.url != nil }
-                        .map { $0.url! }
-                    creative.callTrackingUrls(trackingUrls)
-                    delegate?.adThirdQuartile(vastTracker: self, ad: creative.vastAd)
-                }
-            }
-
-            currentTrackingCreative = creative
-        } else {
-            if !creative.trackedComplete && creative.trackedStart {
-                creative.trackedComplete = true
-                let trackingUrls = creative.creative.trackingEvents
-                    .filter { $0.type == .complete && $0.url != nil }
+                    .filter { $0.type == .firstQuartile && $0.url != nil }
                     .map { $0.url! }
                 creative.callTrackingUrls(trackingUrls)
-                delegate?.adComplete(vastTracker: self, ad: creative.vastAd)
-                completedAdAccumulatedDuration += creative.duration
+                delegate?.adFirstQuartile(vastTracker: self, ad: creative.vastAd)
             }
-
-            vastAds.removeFirst()
-            currentTrackingCreative = nil
-            if vastAds.count > 0 {
-                try? updateProgress(time: time)
-            } else {
-                trackingStatus = .complete
-                delegate?.adBreakComplete(vastTracker: self, vastModel: vastModel)
+        } else if playhead > creative.midpoint && playhead < creative.thirdQuartile {
+            if !creative.trackedMidpoint {
+                creative.trackedMidpoint = true
+                let trackingUrls = creative.creative.trackingEvents
+                    .filter { $0.type == .midpoint && $0.url != nil }
+                    .map { $0.url! }
+                creative.callTrackingUrls(trackingUrls)
+                delegate?.adMidpoint(vastTracker: self, ad: creative.vastAd)
             }
+        } else if playhead > creative.thirdQuartile && playhead < creative.duration {
+            if !creative.trackedThirdQuartile {
+                creative.trackedThirdQuartile = true
+                let trackingUrls = creative.creative.trackingEvents
+                    .filter { $0.type == .thirdQuartile && $0.url != nil }
+                    .map { $0.url! }
+                creative.callTrackingUrls(trackingUrls)
+                delegate?.adThirdQuartile(vastTracker: self, ad: creative.vastAd)
+            }
+        }
+        
+        currentTrackingCreative = creative
+    }
+    
+    public func finishedPlayback() throws {
+        guard var creative = currentTrackingCreative else {
+            trackingStatus = .errored
+            throw TrackingError.internalError(msg: "Unable to find current creative to track")
+        }
+        
+        if !creative.trackedComplete && creative.trackedStart {
+            creative.trackedComplete = true
+            let trackingUrls = creative.creative.trackingEvents
+                .filter { $0.type == .complete && $0.url != nil }
+                .map { $0.url! }
+            creative.callTrackingUrls(trackingUrls)
+            delegate?.adComplete(vastTracker: self, ad: creative.vastAd)
+            completedAdAccumulatedDuration += creative.duration
+        }
+        
+        vastAds.removeFirst()
+        currentTrackingCreative = nil
+        if vastAds.count > 0 {
+            try? updateProgress(time: 0.0)
+        } else {
+            trackingStatus = .complete
+            delegate?.adBreakComplete(vastTracker: self, vastModel: vastModel)
         }
     }
 
@@ -262,7 +270,7 @@ public class VastTracker {
         }
     }
 
-    public func clicked(withCustomAction custom: Bool = false) throws -> URL? {
+    public func clicked() throws -> URL? {
         if let trackingCreative = currentTrackingCreative {
             trackClicks(for: trackingCreative)
             

--- a/VastClient/VastClient/VastTracker.swift
+++ b/VastClient/VastClient/VastTracker.swift
@@ -41,7 +41,7 @@ public class VastTracker {
         self.startTime = startTime
         self.vastModel = vastModel
         self.vastAds = vastModel.ads
-            .filter { supportAdBuffets ? true : $0.sequence != nil }
+            .filter { supportAdBuffets ? true : $0.sequence == nil || $0.sequence == 0 }
             .sorted(by: { $0.sequence ?? 0 < $1.sequence ?? 0 })
         self.trackingStatus = .tracking
         self.delegate = delegate

--- a/VastClient/VastClient/models/XML schema/VastAd.swift
+++ b/VastClient/VastClient/models/XML schema/VastAd.swift
@@ -50,7 +50,7 @@ public struct VastAd {
     
     // attribute
     public let id: String
-    public let sequence: Int
+    public let sequence: Int?
     public let conditionalAd: Bool?
     
     // VAST/Ad/Wrapper and VAST/Ad/InLine elements
@@ -94,7 +94,7 @@ extension VastAd {
             }
         }
         self.id = id
-        self.sequence = Int(sequence) ?? 0
+        self.sequence = Int(sequence)
         self.conditionalAd = conditionalAd.boolValue
         self.type = .unknown
     }

--- a/VastClient/VastClient/models/XML schema/VastStaticResource.swift
+++ b/VastClient/VastClient/models/XML schema/VastStaticResource.swift
@@ -20,14 +20,14 @@ public struct VastStaticResource {
 extension VastStaticResource {
     init?(attrDict: [String: String]) {
         var creativeTypeValue: String?
-        attrDict.compactMap { key, value -> (VastIconClickTrackingAttribute, String)? in
-            guard let newKey = VastIconClickTrackingAttribute(rawValue: key) else {
+        attrDict.compactMap { key, value -> (VastStaticResourceAttribute, String)? in
+            guard let newKey = VastStaticResourceAttribute(rawValue: key) else {
                 return nil
             }
             return (newKey, value)
             }.forEach { (key, value) in
                 switch key {
-                case .id:
+                case .creativeType:
                     creativeTypeValue = value
                 }
         }

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -158,6 +158,8 @@ extension VastXMLParser: XMLParserDelegate {
                 currentIcon = VastIcon(attrDict: attributeDict)
             case VastIconElements.staticResource:
                 currentStaticResource = VastStaticResource(attrDict: attributeDict)
+            case VastIconElements.iconClicks:
+                currentIcon?.iconClicks = IconClicks()
             case IconClicksElements.iconClickTracking:
                 currentIconClickTracking = VastIconClickTracking(attrDict: attributeDict)
 // TODO: uncomments and fix parsing for /CompanionAds
@@ -278,8 +280,6 @@ extension VastXMLParser: XMLParserDelegate {
                     currentViewableImpression?.viewUndetermined.append(url)
                 }
             case AdElements.verification:
-                currentVerification?.viewableImpression = currentVerificationViewableImpression
-                currentVerificationViewableImpression = nil
                 if let verification = currentVerification {
                     currentVastAd?.adVerifications.append(verification)
                     currentVerification = nil
@@ -354,6 +354,26 @@ extension VastXMLParser: XMLParserDelegate {
                     currentLinearCreative?.trackingEvents.append(trackingEvent)
                     currentTrackingEvent = nil
                 }
+            case CreativeLinearElements.icon:
+                if let currentIcon = currentIcon {
+                    currentLinearCreative?.icons.append(currentIcon)
+                    
+                }
+                currentIcon = nil
+            case VastIconElements.staticResource:
+                currentStaticResource?.url = URL(string: currentContent)
+                if let staticResource = currentStaticResource {
+                    currentIcon?.staticResource.append(staticResource)
+                }
+                currentStaticResource = nil
+            case IconClicksElements.iconClickThrough:
+                currentIcon?.iconClicks?.iconClickThrough = URL(string: currentContent)
+            case IconClicksElements.iconClickTracking:
+                currentIconClickTracking?.url = URL(string: currentContent)
+                if let currentIconClickTracking = currentIconClickTracking {
+                    currentIcon?.iconClicks?.iconClickTracking.append(currentIconClickTracking)
+                }
+                currentIconClickTracking = nil
                 
 // TODO: uncomments and fix parsing for /CompanionAds
 //            case ExtensionElements.creativeparameter:

--- a/VastClient/VastClientTests/Assets/Vast3/EventTracking-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/EventTracking-test3.swift
@@ -44,7 +44,7 @@ extension VastModel {
             // TODO: this is not part of the current model
         ]
         
-        let ad = VastAd(type: .inline, id: "20001", sequence: 0, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        let ad = VastAd(type: .inline, id: "20001", sequence: nil, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: nil)
         
         return VastModel(version: "3.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/Assets/Vast3/InlineLinearTag-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/InlineLinearTag-test3.swift
@@ -45,7 +45,7 @@ extension VastModel {
             // TODO: this is not part of the current model
         ]
         
-        let ad = VastAd(type: .inline, id: "20001", sequence: 0, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        let ad = VastAd(type: .inline, id: "20001", sequence: nil, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: nil)
     
         return VastModel(version: "3.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/Assets/Vast3/VideoClicksAndClickTrackingInline-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/VideoClicksAndClickTrackingInline-test3.swift
@@ -46,7 +46,7 @@ extension VastModel {
             // TODO: this is not part of the current model
         ]
         
-        let ad = VastAd(type: .inline, id: "20009", sequence: 0, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: adTitle, adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        let ad = VastAd(type: .inline, id: "20009", sequence: nil, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: adTitle, adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: nil)
         
         return VastModel(version: "3.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/Assets/Vast3/WrapperTag-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/WrapperTag-test3.swift
@@ -27,7 +27,7 @@ extension VastModel {
         
         let wrapper = VastWrapper(followAdditionalWrappers: nil, allowMultipleAds: nil, fallbackOnNoAd: nil, adTagUri: adTagUri)
         
-        let ad = VastAd(type: .wrapper, id: "20011", sequence: 0, conditionalAd: nil, adSystem: adSystem, impressions: impressions, adVerifications: [], viewableImpression: nil, pricing: nil, errors: errors, creatives: [creative], extensions: extensions, adTitle: nil, adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: wrapper)
+        let ad = VastAd(type: .wrapper, id: "20011", sequence: nil, conditionalAd: nil, adSystem: adSystem, impressions: impressions, adVerifications: [], viewableImpression: nil, pricing: nil, errors: errors, creatives: [creative], extensions: extensions, adTitle: nil, adCategories: [], description: nil, advertiser: nil, surveys: [], wrapper: wrapper)
         
         return VastModel(version: "3.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
@@ -34,7 +34,7 @@ extension VastModel {
             VastMediaFile(delivery: "progressive", type: "video/mp4", width: "640", height: "360", codec: "0", id: "5246", bitrate: 600, minBitrate: 500, maxBitrate: 700, scalable: true, maintainAspectRatio: true, apiFramework: nil, url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4"))
         ]
         
-        let interactiveMediaFiles: [VastInteractiveCreativeFile] = [VastInteractiveCreativeFile(type: "interactive/mp", apiFramework: "frameworkurl", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4"))]
+        let interactiveMediaFiles: [VastInteractiveCreativeFile] = [VastInteractiveCreativeFile(type: "interactive/mp4", apiFramework: "frameworkurl", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4"))]
         
         let icon1Clicks = IconClicks(iconClickThrough: URL(string: "https://iabtechlab.com")!, iconClickTracking: [VastIconClickTracking(id: "iconclick", url: URL(string: "https://iabtechlab.com")!)])
         let icon1StaticResources: [VastStaticResource] = [VastStaticResource(creativeType: "image/jpg", url: URL(string: "https://images-nl.ott.kaltura.com/Service.svc/GetImage/p/436/entry_id/422ec4ffe19d4435aaca092dc83bae0c_12/version/0/quality/85/width/118/height/15/"))]
@@ -53,7 +53,7 @@ extension VastModel {
             VastExtension(type: "iab-Count", creativeParameters: [])
         ]
         
-        let vastVerification1 = VastVerification(vendor: URL(string: "VendorURL"), viewableImpression: nil, javaScriptResource: [VastResource(apiFramework: "frameworkname", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"))], flashResources: [])
+        let vastVerification1 = VastVerification(vendor: URL(string: "VendorURL"), viewableImpression: nil, javaScriptResource: [VastResource(apiFramework: "frameworkname", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4")), VastResource(apiFramework: "frameworkname", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"))], flashResources: [])
         
         let vastVerification2 = VastVerification(vendor: URL(string: "VendorURL"), viewableImpression: VastViewableImpression(id: "verificationViewableImpressionID", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"), viewable: [], notViewable: [], viewUndetermined: []), javaScriptResource: [], flashResources: [VastResource(apiFramework: "frameworkname", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"))])
         

--- a/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
@@ -1,0 +1,66 @@
+//
+//  InlineLinearIcons-test.swift
+//  VastClientTests
+//
+//  Created by Jan Bednar on 10/12/2018.
+//  Copyright © 2018 John Gainfort Jr. All rights reserved.
+//
+import Foundation
+@testable import VastClient
+
+extension VastModel {
+    static let inlineLinearIcons: VastModel = {
+        let adSystem = VastAdSystem(version: "4.0", system: "iabtechlab")
+        let impressions = VastImpression(id: "Impression-ID", url: URL(string: "http://example.com/track/impression")!)
+        let pricing = VastPricing(model: .cpm, currency: "USD", pricing: 25.0)
+        let errors = [URL(string: "http://example.com/error")!]
+        
+        let categories: [VastAdCategory] = [VastAdCategory(authority: URL(string: "authority"), category: "category")]
+        
+        let videoClicks: [VastVideoClick] = [
+            VastVideoClick(id: "blog", type: .clickThrough, url: URL(string: "https://iabtechlab.com"))
+        ]
+        let trackingEvents: [VastTrackingEvent] = [
+            VastTrackingEvent(type: .start, offset: 33323, url: URL(string: "http://example.com/tracking/start"), tracked: false),
+            VastTrackingEvent(type: .firstQuartile, offset: nil, url: URL(string: "http://example.com/tracking/firstQuartile"), tracked: false),
+            VastTrackingEvent(type: .midpoint, offset: nil, url: URL(string: "http://example.com/tracking/midpoint"), tracked: false),
+            VastTrackingEvent(type: .thirdQuartile, offset: nil, url: URL(string: "http://example.com/tracking/thirdQuartile"), tracked: false),
+            VastTrackingEvent(type: .complete, offset: nil, url: URL(string: "http://example.com/tracking/complete"), tracked: false)
+        ]
+        
+        let mediaFiles: [VastMediaFile] = [
+            VastMediaFile(delivery: "progressive", type: "video/mp4", width: "1280", height: "720", codec: "0", id: "5241", bitrate: 2000, minBitrate: 1500, maxBitrate: 2500, scalable: true, maintainAspectRatio: true, apiFramework: nil, url: URL(string: "https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4")),
+            VastMediaFile(delivery: "progressive", type: "video/mp4", width: "854", height: "480", codec: "0", id: "5244", bitrate: 1000, minBitrate: 700, maxBitrate: 1500, scalable: true, maintainAspectRatio: true, apiFramework: nil, url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4")),
+            VastMediaFile(delivery: "progressive", type: "video/mp4", width: "640", height: "360", codec: "0", id: "5246", bitrate: 600, minBitrate: 500, maxBitrate: 700, scalable: true, maintainAspectRatio: true, apiFramework: nil, url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4"))
+        ]
+        
+        let interactiveMediaFiles: [VastInteractiveCreativeFile] = [VastInteractiveCreativeFile(type: "interactive/mp", apiFramework: "frameworkurl", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4"))]
+        
+        let icon1Clicks = IconClicks(iconClickThrough: URL(string: "https://iabtechlab.com")!, iconClickTracking: [VastIconClickTracking(id: "iconclick", url: URL(string: "https://iabtechlab.com")!)])
+        let icon1StaticResources: [VastStaticResource] = [VastStaticResource(creativeType: "image/jpg", url: URL(string: "https://images-nl.ott.kaltura.com/Service.svc/GetImage/p/436/entry_id/422ec4ffe19d4435aaca092dc83bae0c_12/version/0/quality/85/width/118/height/15/"))]
+        let icon1 = VastIcon(program: "programName", width: 118, height: 15, xPosition: "left", yPosition: "top", duration: 0, offset: 5, apiFramework: "", pxratio: 1, iconViewTracking: nil, iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
+        
+        let icon2 = VastIcon(program: "programName2", width: 118, height: 15, xPosition: "100", yPosition: "100", duration: 0, offset: 0, apiFramework: "", pxratio: 1, iconViewTracking: nil, iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
+        
+        let icons: [VastIcon] = [icon1, icon2]
+        
+        let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
+        let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
+        
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        
+        let extensions: [VastExtension] = [
+            VastExtension(type: "iab-Count", creativeParameters: [])
+        ]
+        
+        let vastVerification1 = VastVerification(vendor: URL(string: "VendorURL"), viewableImpression: nil, javaScriptResource: [VastResource(apiFramework: "frameworkname", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"))], flashResources: [])
+        
+        let vastVerification2 = VastVerification(vendor: URL(string: "VendorURL"), viewableImpression: VastViewableImpression(id: "verificationViewableImpressionID", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"), viewable: [], notViewable: [], viewUndetermined: []), javaScriptResource: [], flashResources: [VastResource(apiFramework: "frameworkname", url: URL(string: "https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4"))])
+        
+        let adVerifications: [VastVerification] = [vastVerification1, vastVerification2]
+        
+        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: adVerifications, viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: categories, description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        
+        return VastModel(version: "4.0", ads: [ad], errors: [])
+    }()
+}

--- a/VastClient/VastClientTests/Assets/Vast4/Inline_linear_icons-test.xml
+++ b/VastClient/VastClientTests/Assets/Vast4/Inline_linear_icons-test.xml
@@ -17,12 +17,12 @@
             </ViewableImpression>
             <AdVerifications>
                 <Verification vendor="VendorURL">
-                    <JavascriptResource apiFramework="frameworkname">
+                    <JavaScriptResource apiFramework="frameworkname">
                         <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
-                    </JavascriptResource>
-                    <JavascriptResource apiFramework="frameworkname">
+                    </JavaScriptResource>
+                    <JavaScriptResource apiFramework="frameworkname">
                         <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
-                    </JavascriptResource>
+                    </JavaScriptResource>
                 </Verification>
                 <Verification vendor="VendorURL">
                     <FlashResource apiFramework="frameworkname">

--- a/VastClient/VastClientTests/Assets/Vast4/Inline_linear_icons-test.xml
+++ b/VastClient/VastClientTests/Assets/Vast4/Inline_linear_icons-test.xml
@@ -1,0 +1,109 @@
+<VAST version="4.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.iab.com/VAST">
+    <Ad id="20001" sequence="1">
+        <InLine>
+            <AdSystem version="4.0">iabtechlab</AdSystem>
+            <Error>http://example.com/error</Error>
+            <Extensions>
+                <Extension type="iab-Count">
+                    <total_available>
+                        <![CDATA[ 2 ]]>
+                    </total_available>
+                </Extension>
+            </Extensions>
+            <Impression id="Impression-ID">http://example.com/track/impression</Impression>
+            <ViewableImpression id="VImpression-ID">
+                <Viewable>http://example.com/track/Viewable</Viewable>
+                <ViewUndetermined>http://example.com/track/ViewUndetermined</ViewUndetermined>
+            </ViewableImpression>
+            <AdVerifications>
+                <Verification vendor="VendorURL">
+                    <JavascriptResource apiFramework="frameworkname">
+                        <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
+                    </JavascriptResource>
+                    <JavascriptResource apiFramework="frameworkname">
+                        <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
+                    </JavascriptResource>
+                </Verification>
+                <Verification vendor="VendorURL">
+                    <FlashResource apiFramework="frameworkname">
+                        <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
+                    </FlashResource>
+                    <ViewableImpression id="verificationViewableImpressionID">
+                        <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
+                    </ViewableImpression>
+                </Verification>
+            </AdVerifications>
+            <Category authority="authority">category</Category>
+            <Pricing model="cpm" currency="USD">
+                <![CDATA[ 25.00 ]]>
+            </Pricing>
+            <AdTitle>iabtechlab video ad</AdTitle>
+            <Creatives>
+                <Creative id="5480" sequence="1" adId="2447226">
+                    <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+                    <Linear>
+                        <TrackingEvents>
+                            <Tracking event="start" offset="09:15:23">http://example.com/tracking/start</Tracking>
+                            <Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+                            <Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+                            <Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+                            <Tracking event="complete">http://example.com/tracking/complete</Tracking>
+                        </TrackingEvents>
+                        <Duration>00:00:16</Duration>
+                        <MediaFiles>
+                            <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="0">
+                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2016/07/VAST-4.0-Short-Intro.mp4]]>
+                            </MediaFile>
+                            <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="0">
+                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-mid-resolution.mp4]]>
+                            </MediaFile>
+                            <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="0">
+                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4]]>
+                            </MediaFile>
+                            <InteractiveCreativeFile type="interactive/mp4" apiFramework="frameworkurl">
+                                <![CDATA[https://iabtechlab.com/wp-content/uploads/2017/12/VAST-4.0-Short-Intro-low-resolution.mp4]]>
+                            </InteractiveCreativeFile>
+                            <Mezzanine>
+                                <![CDATA[https://iabtechlab.com/mezzanineurl]]>
+                            </Mezzanine>
+                        </MediaFiles>
+                        <Icons>
+                            <Icon program="programName" width="118" height="15" xPosition="left" yPosition="top" offset="00:00:05">
+                                <StaticResource creativeType="image/jpg">
+                                    <![CDATA[https://images-nl.ott.kaltura.com/Service.svc/GetImage/p/436/entry_id/422ec4ffe19d4435aaca092dc83bae0c_12/version/0/quality/85/width/118/height/15/]]>
+                                </StaticResource>
+                                <IconClicks>
+                                    <IconClickThrough>
+                                        <![CDATA[https://iabtechlab.com]]>
+                                    </IconClickThrough>
+                                    <IconClickTracking id="iconclick">
+                                        <![CDATA[https://iabtechlab.com]]>
+                                    </IconClickTracking>
+                                </IconClicks>
+                            </Icon>
+                            
+                            <Icon program="programName2" width="118" height="15" xPosition="100" yPosition="100">
+                                <StaticResource creativeType="image/jpg">
+                                    <![CDATA[https://images-nl.ott.kaltura.com/Service.svc/GetImage/p/436/entry_id/422ec4ffe19d4435aaca092dc83bae0c_12/version/0/quality/85/width/118/height/15/]]>
+                                </StaticResource>
+                                <IconClicks>
+                                    <IconClickThrough>
+                                        <![CDATA[https://iabtechlab.com]]>
+                                    </IconClickThrough>
+                                    <IconClickTracking id="iconclick">
+                                        <![CDATA[https://iabtechlab.com]]>
+                                    </IconClickTracking>
+                                </IconClicks>
+                            </Icon>
+                        </Icons>
+                        <VideoClicks>
+                            <ClickThrough id="blog">
+                                <![CDATA[https://iabtechlab.com]]>
+                            </ClickThrough>
+                        </VideoClicks>
+                    </Linear>
+                </Creative>
+            </Creatives>
+        </InLine>
+    </Ad>
+</VAST>

--- a/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsInlineModel-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsInlineModel-test.swift
@@ -38,7 +38,7 @@ extension VastModel {
         
         let extensions: [VastExtension] = []
         
-        let ad = VastAd(type: .inline, id: "29619", sequence: 0, conditionalAd: nil, adSystem: adSystem, impressions: impressions, adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "Ster en Cultuur (weekpak. volwas)ONLINE", adCategories: categories, description: "Ster en Cultuur (weekpak. volwas)ONLINE", advertiser: nil, surveys: [], wrapper: nil)
+        let ad = VastAd(type: .inline, id: "29619", sequence: nil, conditionalAd: nil, adSystem: adSystem, impressions: impressions, adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "Ster en Cultuur (weekpak. volwas)ONLINE", adCategories: categories, description: "Ster en Cultuur (weekpak. volwas)ONLINE", advertiser: nil, surveys: [], wrapper: nil)
         
         return VastModel(version: "2.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/VastXMLParserTests.swift
+++ b/VastClient/VastClientTests/VastXMLParserTests.swift
@@ -100,6 +100,11 @@ class VastXMLParserTests: XCTestCase {
         XCTAssertEqual(model.errors.count, 0)
     }
     
+    func test_inlineLinearIcons() {
+        let model = self.loadVastFile(named: "Inline_linear_icons-test")
+        XCTAssertEqual(model, VastModel.inlineLinearIcons)
+    }
+    
     private func loadVastFile(named filename: String) -> VastModel {
         let parser = VastXMLParser()
         let bundle = Bundle(for: type(of: self))


### PR DESCRIPTION
Couple things in this PR. the diff is not very well handled in the tracker, consider comparing using split view, its much clearer.

- Made `sequence` parameter optional for ads - it should not be there or it has to be a not 0 number
- Fixed initializer for static resource
- Added parsing of Icons to xml parser and tests
- Split tracking progress:
Previously the progress was being tracked in one function and the same function was deciding when the content should finish. Trouble is that the duration of ad that comes from VAST do not account for miliseconds - therefore the ads were not played in full or the tracker did get stuck, because it never "ended".

I've split this into 2 functions to track progress and to track finished playback. Host app has to account for this.