### PR TITLE
NPOS-5099: Time wrapper limitation

### DIFF
--- a/VastClient/VastClient/VastClient.swift
+++ b/VastClient/VastClient/VastClient.swift
@@ -9,12 +9,14 @@
 import Foundation
 
 public struct VastClientOptions {
-    public var wrapperLimit: Int
-}
-
-extension VastClientOptions {
-    public init() {
-        self.wrapperLimit = 7
+    public let wrapperLimit: Int
+    public let singleWrapperTimeLimit: TimeInterval
+    public let timeLimit: TimeInterval
+    
+    public init(wrapperLimit: Int = 5, singleWrapperTimeLimit: TimeInterval = 5, timeLimit: TimeInterval = 15) {
+        self.wrapperLimit = wrapperLimit
+        self.singleWrapperTimeLimit = singleWrapperTimeLimit
+        self.timeLimit = timeLimit
     }
 }
 
@@ -25,17 +27,17 @@ public class VastClient {
     public init(options: VastClientOptions = VastClientOptions()) {
         self.options = options
     }
-
-    public func parseVast(withContentsOf url: URL) throws -> VastModel {
+    
+    public func parseVast(withContentsOf url: URL, completion: @escaping (VastModel?, Error?) -> ()) {
         let parser = VastParser(options: options)
-        return try parser.parse(url: url)
+        parser.parse(url: url, completion: completion)
     }
     
     public func parseVMAP(withContentsOf url: URL) throws -> VMAPModel {
         let parser = VMAPParser(options: options)
         return try parser.parse(url: url)
-        
     }
+    
     
     /**
      Load local files easily with schema specifier "test://"
@@ -45,8 +47,8 @@ public class VastClient {
      - parameter url: URL of local or remote file. For local files the url has to start with `test://` and can not contain ".xml" extension. For example: `test://Pubads_Inline_Model-test` to load file named "Pubads_Inline_Model-test.xml"
      - parameter testbundle: bundle of the test that contains local test xml files
      */
-    func parseVast(withContentsOf url: URL, testBundle: Bundle) throws -> VastModel {
+    func parseVast(withContentsOf url: URL, testBundle: Bundle, completion: @escaping (VastModel?, Error?) -> ()) {
         let parser = VastParser(options: options, testFileBundle: testBundle)
-        return try parser.parse(url: url)
+        parser.parse(url: url, completion: completion)
     }
 }

--- a/VastClient/VastClient/VastClient.swift
+++ b/VastClient/VastClient/VastClient.swift
@@ -13,7 +13,7 @@ public struct VastClientOptions {
     public let singleWrapperTimeLimit: TimeInterval
     public let timeLimit: TimeInterval
     
-    public init(wrapperLimit: Int = 5, singleWrapperTimeLimit: TimeInterval = 5, timeLimit: TimeInterval = 15) {
+    public init(wrapperLimit: Int = 5, singleWrapperTimeLimit: TimeInterval = 5, timeLimit: TimeInterval = 10) {
         self.wrapperLimit = wrapperLimit
         self.singleWrapperTimeLimit = singleWrapperTimeLimit
         self.timeLimit = timeLimit

--- a/VastClient/VastClient/constants/VastError.swift
+++ b/VastClient/VastClient/constants/VastError.swift
@@ -14,5 +14,7 @@ public enum VastError: Error {
     case unableToParseDocument
     case unableToCreateXMLParser
     case wrapperLimitReached
+    case singleRequestTimeLimitReached
+    case wrapperTimeLimitReached
     case internalError
 }

--- a/VastClient/VastClientTests/VastXMLParserPubadsWrapperTests.swift
+++ b/VastClient/VastClientTests/VastXMLParserPubadsWrapperTests.swift
@@ -34,9 +34,33 @@ class VastXMLParserPubadsWrapperTests: XCTestCase {
     
     func test_parse_response_success() {
         let url = URL(string: "test://Pubads_Wrapper_Model-test")!
-        let model = try? client.parseVast(withContentsOf: url, testBundle: bundle)
-        XCTAssertTrue(model != nil)
-        XCTAssertEqual(model, VastModel.pubadsModel)
+        let expect = expectation(description: "model")
+        var model: VastModel?
+        
+        client.parseVast(withContentsOf: url, testBundle: bundle) { (vastModel, error) in
+            model = vastModel
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 15, handler: { _ in
+            XCTAssertTrue(model != nil)
+            XCTAssertEqual(model, VastModel.pubadsModel)
+        })
+    }
+    
+    func test_parse_remote_response_success() {
+        let url = URL(string: "https://pubads.g.doubleclick.net/gampad/ads?slotname=/9233/npoplayer.nl/pauw&sz=720x404&cust_params=genre%3Dinformatief%26dur%3D3392%26prid%3DBV_101388618%26srid%3DVARA_101377247%26net%3D%26player%3Dweb%26device%3Ddesktop%26os%3Dwindows%26osversion%3D10%26playername%3Dnpo-app-desktop%26playerversion%3D5.20.0%26omroep%3Dbnnvara%26programma%3Dpauw%26ncc%3D%24%24ncc%24%24%26stationid%3Dnpo%26afleveringstitel%3Dpauw%26subgenre%3Dnieuws%2Factualiteiten%26abtest%3DA2%26site%3Dnpostart%26interessechannels%3D&url=https://www.npostart.nl/pauw/15-10-2018/BV_101388618%3Fttype%3Dchoice%26tevent%3D%257B%2522spvid%2522%253A%25220%253AZNIXpyFzDnLAWOOSrVawDvIiB7y3LWAu%2522%252C%2522comScoreName%2522%253A%2522npo.home.index%2522%252C%2522brand%2522%253A%2522npoportal%2522%252C%2522section%2522%253A%2522home%2522%252C%2522broadcaster%2522%253A%2522npo%2522%252C%2522subBroadcaster%2522%253A%2522npo%2522%252C%2522brandType%2522%253A%2522zenderportal%2522%252C%2522platform%2522%253A%2522site%2522%252C%2522platformType%2522%253A%2522site%2522%252C%2522avType%2522%253A%2522video%2522%252C%2522panel%2522%253A%2522home.regular.1%2522%252C%2522type%2522%253A%2522editorial%2522%252C%2522offerId%2522%253A%2522749540cd-0f0f-4817-bc95-db37bf3a5cc9%2522%252C%2522destination%2522%253A%257B%2522contentId%2522%253A%2522BV_101388618%2522%252C%2522index%2522%253A1%252C%2522numberDisplayed%2522%253A10%252C%2522recommender%2522%253A%2522meest-bekeken%2522%257D%252C%2522sourceContentId%2522%253A%2522no_source_available%2522%257D&unviewed_position_start=1&impl=s&env=vp&gdfp_req=1&ad_rule=0&output=xml_vast4&video_url_to_fetch=%5Breferrer_url%5D&vad_type=linear&vpos=preroll&pod=1&vrid=1334&pmnd=0&pmxd=30000&pmad=2&is_amp=0&adk=421971784&correlator=461400697701781&scor=2627431874535605&pucrd=CgwIARAAGAAgACgAOAF4Aw&ged=ve4_td2_er0.0.152.300_vi0.0.392.696_vp100_eb24424&osd=2&jar=2018-10-17-14&hl=nl&frm=2&sdkv=h.3.244.2&sdki=44d&mpt=videojs-ima&mpv=0.2.0&sdr=1&u_so=l&afvsz=450x50,468x60,480x70&kfa=0&tfcd=0")!
+        let expect = expectation(description: "model")
+        var model: VastModel?
+        
+        client.parseVast(withContentsOf: url) { (vastModel, error) in
+            model = vastModel
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5, handler: { _ in
+            XCTAssertTrue(model != nil)
+        })
     }
     
     private func loadVastFile(named filename: String) -> VastModel {


### PR DESCRIPTION
Add a time limitation for the whole VAST request only at this time.

Adding the time limitation for each hop will get complicated as the whole code is synchronous and the mapping of wrappers containing multiple ads will not help us much at the moment.

