### PR TITLE
NPOS-5102: Document supported VAST tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,131 @@
 # IOS Vast Client
 
-IOS Vast Client is a Swift Framework which implements the [VAST 3.0](https://www.iab.com/guidelines/digital-video-ad-serving-template-vast-3-0/) spec.
+IOS Vast Client is a Swift Framework which implements the [VAST 4.0](https://www.iab.com/guidelines/digital-video-ad-serving-template-vast/) spec.
 
 This project is ongoing and in very early stages of development. As this project is being developed we will only target a subset of the VAST spec to meet our immediate needs. We do not recommend to use this library at this time. 
 
 ## Features
 
-* VAST 3.0 Spec Complient
+* VAST 4.0 Spec Complient
 * Vast XML Parser and Validator
 * VAST Impression and Ad Tracking
 * VAST Error Tracking
 
 ## API docs
 
-TODO
+iOS Vast Client containts 2 interfaces for public use.
+
+### VastClient
+
+Fetch and parse VAST file from URL. You can customize behaviour with `VastClientOptions` during initialization of `VastClient`.
+
+`VastClient` result is `VastModel` structure or `Error` in case the fetch failed. You should pass this model to `VastTracker`.
+
+### VastTracker
+
+Handels tracking of ad break progress and errors. Notifies state updates via delegate calls.
+
+#### Initialization
+
+Init `VastTracker` with `VastModel` structure but always make sure to use the actuall `VastAd` and other information provided via delegate function calls - do not keep the `VastModel` as not all information from the `VastModel` might be valid for playback etc.
+
+If you initialize `VastTracker` with delegate - `func adBreakStart(vastTracker: VastTracker, totalAds: Int)` will be called immediately. 
+
+#### Progress
+
+`func updateProgress(time: Double) throws`
+After you initialize `VastTracker` you should call this function with `time = 0` parameter to start tracking ad playback. `VastTracker` will select linear ad to play and will notify you via delegate call `func adStart(vastTracker: VastTracker, ad: VastAd)`
+
+You have to call this function periodically during ad playback.
+These delegate function will be called during normal ad playback and you do not have to react to them - they are only informative
+
+```swift
+func adFirstQuartile(vastTracker: VastTracker, ad: VastAd)
+func adMidpoint(vastTracker: VastTracker, ad: VastAd)
+func adThirdQuartile(vastTracker: VastTracker, ad: VastAd)
+```
+
+#### Ad End
+
+When ad playback ends your app is responsible for calling `finishedPlayback()`.
+Delegate function `func adComplete(vastTracker: VastTracker, ad: VastAd)` will be called.
+
+If there are more ads, next one will be played and your app will receive `func adStart(vastTracker: VastTracker, ad: VastAd)` again. There is no need to call update progress with `time = 0` anymore, this is handeled by the `VastTracker`
+
+If there are no more ads to be played, ad break is finished and delegate `func adBreakComplete(vastTracker: VastTracker, vastModel: VastModel)` will be called.
+
+#### Skipping Ads
+
+Call `public func skip()` to skip ad playback for skippable linear ad at appropriate time. Next ad playback will start.
+
+### Tracking
+
+During ad break, other actions might be invoked by the user or the system.
+`VastTracker` support tracking of these actions:
+
+```
+public func paused(_ val: Bool)
+public func fullscreen(_ val: Bool)
+public func rewind()
+public func muted(_ val: Bool)
+public func acceptedLinearInvitation()
+public func closed()
+public func clicked() -> URL?
+public func clickedWithCustomAction() -> [URL]
+public func error(withReason code: VastErrorCodes?)
+```
+
+## Supported tags
+
+status:
+
+- not parsed
+- parsed - but not used currently, can be used by host app
+- partial - partially supported - might be missing edge cases
+- full - fully supported VAST tag
+
+|tag|status|note|
+|---|---|---|
+|VAST|full|-|
+|Ad|partial|single and AdPods supported, AdBuffet treated like single ad|
+|InLine|full|-|
+|AdSystem|parsed||
+|AdTitle|full||
+|Impression|parsed||
+|Category|parsed||
+|Description|parsed||
+|Advertiser|parsed||
+|Pricing|parsed||
+|Survey|parsed||
+|Error|full|host app needs to initiate the error tracking|
+|ViewableImpression|parsed|missing tracker method|
+|Creatives|full||
+|Creative|full||
+|UniversalAdId|parsed||
+|CreativeExtensions|parsed||
+|CreativeExtension|parsed||
+|Linear|full||
+|Duration|full||
+|AdParameters|parsed|but only as a string - this might be XML content that will need validation if it is necessary for use|
+|MediaFiles|full||
+|MediaFile|parsed|up to host app to handle playback|
+|Mezzanine|not parsed||
+|InteractiveCreativeFile|parsed||
+|VideoClicks|full|host app has to initiate tracking events for clicks|
+|ClickThrough|full||
+||ClickTracking|full|
+|CustomClick|partial|host app can track custom clicks via tracker, but the functionality is not specified|
+|Icons|full||
+|Icon|full|host app has to handle icon placement, visibility and icon clicks|
+|IconViewTracking|parsed|View action tracking not implemented|
+|IconClicks|full||
+|IconClickThrough|full||
+|IconClickTracking|full||
+|NonLinearAds|not parsed|no sub-elemets supported|
+|CompanionAds|not parsed|no sub-elemets supported|
+|Wrapper|full||
+|VASTAdTagURI|parsed||
+
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is ongoing and in very early stages of development. As this project
 
 ## API docs
 
-iOS Vast Client containts 2 interfaces for public use.
+iOS Vast Client contains 2 interfaces for public use.
 
 ### VastClient
 
@@ -27,7 +27,7 @@ Handels tracking of ad break progress and errors. Notifies state updates via del
 
 #### Initialization
 
-Init `VastTracker` with `VastModel` structure but always make sure to use the actuall `VastAd` and other information provided via delegate function calls - do not keep the `VastModel` as not all information from the `VastModel` might be valid for playback etc.
+Init `VastTracker` with `VastModel` structure but always make sure to use the actual `VastAd` and other information provided via delegate function calls - do not keep the `VastModel` as not all information from the `VastModel` might be valid for playback etc.
 
 If you initialize `VastTracker` with delegate - `func adBreakStart(vastTracker: VastTracker, totalAds: Int)` will be called immediately. 
 
@@ -50,7 +50,7 @@ func adThirdQuartile(vastTracker: VastTracker, ad: VastAd)
 When ad playback ends your app is responsible for calling `finishedPlayback()`.
 Delegate function `func adComplete(vastTracker: VastTracker, ad: VastAd)` will be called.
 
-If there are more ads, next one will be played and your app will receive `func adStart(vastTracker: VastTracker, ad: VastAd)` again. There is no need to call update progress with `time = 0` anymore, this is handeled by the `VastTracker`
+If there are more ads, next one will be played and your app will receive `func adStart(vastTracker: VastTracker, ad: VastAd)` again. There is no need to call update progress with `time = 0` anymore, this is handled by the `VastTracker`
 
 If there are no more ads to be played, ad break is finished and delegate `func adBreakComplete(vastTracker: VastTracker, vastModel: VastModel)` will be called.
 

--- a/VastClient/VastClient.xcodeproj/project.pbxproj
+++ b/VastClient/VastClient.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		A945EE58219C5C9E0007A079 /* vast4.xsd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = vast4.xsd; sourceTree = "<group>"; };
 		A981D9FA21BEAEF100018FD8 /* Inline_linear_icons-test.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "Inline_linear_icons-test.xml"; sourceTree = "<group>"; };
 		A981D9FC21BEB01800018FD8 /* InlineLinearIcons-test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InlineLinearIcons-test.swift"; sourceTree = "<group>"; };
+		A98767AA21DCC3FB0079EFE3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		A9A3FFB521BA5B4C008DB5D6 /* TestFullVast4.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TestFullVast4.xml; sourceTree = "<group>"; };
 		A9A3FFB721BA5CBE008DB5D6 /* FullVast4-test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullVast4-test.swift"; sourceTree = "<group>"; };
 		A9A84FEB21A3053200949C4B /* VastParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VastParser.swift; sourceTree = "<group>"; };
@@ -247,6 +248,7 @@
 		0F7B97752077CB340096438D = {
 			isa = PBXGroup;
 			children = (
+				A98767AA21DCC3FB0079EFE3 /* README.md */,
 				0F7B97812077CB340096438D /* VastClient */,
 				0F7B978C2077CB340096438D /* VastClientTests */,
 				0F7B97802077CB340096438D /* Products */,

--- a/VastClient/VastClient/constants/TrackingError.swift
+++ b/VastClient/VastClient/constants/TrackingError.swift
@@ -13,4 +13,5 @@ public enum TrackingError: Error {
     case unableToUpdateProgress(msg: String)
     case unableToProvideCreativeClickThroughUrls
     case internalError(msg: String)
+    case unableToSkipAdAtThisTime
 }

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -240,6 +240,8 @@ extension VastXMLParser: XMLParserDelegate {
                 }
             case AdElements.description:
                 currentVastAd?.description = currentContent
+            case AdElements.advertiser:
+                currentVastAd?.advertiser = currentContent
             case AdElements.pricing:
                 currentVastPricing?.pricing = currentContent.doubleValue
                 if let pricing = currentVastPricing {

--- a/VastClient/VastClientTests/Assets/Vast4/AdVerification-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/AdVerification-test.swift
@@ -55,7 +55,9 @@ extension VastModel {
             VastVerification(vendor: nil, viewableImpression: nil, javaScriptResource: [VastResource(apiFramework: nil, url: URL(string: "https://verificationcompany.com/untrusted.js"))], flashResources: [])
         ]
         
-        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: false, adSystem: adSystem, impressions: [impressions], adVerifications: adVerifications, viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: categories, description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        let advertiser = "IAB Sample Company"
+        
+        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: false, adSystem: adSystem, impressions: [impressions], adVerifications: adVerifications, viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: categories, description: nil, advertiser: advertiser, surveys: [], wrapper: nil)
         
         return VastModel(version: "4.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/Assets/Vast4/InlineSimple-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineSimple-test.swift
@@ -48,7 +48,9 @@ extension VastModel {
         
         let extensions: [VastExtension] = []
         
-        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: false, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "Inline Simple Ad", adCategories: categories, description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        let advertiser = "IAB Sample Company"
+        
+        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: false, adSystem: adSystem, impressions: [impressions], adVerifications: [], viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "Inline Simple Ad", adCategories: categories, description: nil, advertiser: advertiser, surveys: [], wrapper: nil)
         
         return VastModel(version: "4.0", ads: [ad], errors: [])
     }()


### PR DESCRIPTION
Add basic documentation and Vast tag status to readme
add option for host to initialize VastTracker without delegate and be able to read total ad count.
Parse advertiser tag
Add Tracking error when skip is not allowed