### PR TITLE
NPOS-4656: Vast 4 file tests, XML parser fixes and Example project re-work

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ status:
 
 ## Getting Started
 
-TODO
+Check out the VastClientWrapper project for example implementation
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ status:
 |ClickThrough|full||
 ||ClickTracking|full|
 |CustomClick|partial|host app can track custom clicks via tracker, but the functionality is not specified|
-|Icons|full||
+|Icons|partial|iFrame and HTML resources not parsed|
 |Icon|full|host app has to handle icon placement, visibility and icon clicks|
 |IconViewTracking|parsed|View action tracking not implemented|
 |IconClicks|full||

--- a/VastClient/VastClient/VastTracker.swift
+++ b/VastClient/VastClient/VastTracker.swift
@@ -294,7 +294,7 @@ public class VastTracker {
 
     public func skip() throws {
         if let creative = currentTrackingCreative {
-            guard let skipOffset = creative.vastAd.creatives.first?.linear?.skipOffset?.toSeconds, skipOffset < currentTime else {
+            guard let skipOffset = creative.vastAd.creatives.first?.linear?.skipOffset?.toSeconds, skipOffset < playhead else {
                 throw TrackingError.unableToSkipAdAtThisTime
             }
             
@@ -302,6 +302,8 @@ public class VastTracker {
                 .filter { $0.type == .skip && $0.url != nil }
                 .map { $0.url! }
             creative.callTrackingUrls(trackingUrls)
+            
+            completedAdAccumulatedDuration += creative.duration
             try tryToPlayNext()
         } else {
             throw TrackingError.internalError(msg: "Unable to find current creative to track")

--- a/VastClient/VastClient/VastTracker.swift
+++ b/VastClient/VastClient/VastTracker.swift
@@ -246,7 +246,7 @@ public class VastTracker {
         if let creative = currentTrackingCreative {
             let trackingUrls = creative.creative.trackingEvents
                 .filter { event in
-                    let type = val ? event.type == .fullscreen || event.type == .expand : event.type == .resume || event.type == .collapse
+                    let type = val ? event.type == .fullscreen || event.type == .playerExpand : event.type == .resume || event.type == .playerCollapse
                     return type && event.url != nil
                 }
                 .map { $0.url! }

--- a/VastClient/VastClient/models/XML schema/VastIcon.swift
+++ b/VastClient/VastClient/models/XML schema/VastIcon.swift
@@ -41,8 +41,6 @@ public struct VastIcon {
     public var iconViewTracking: [URL] = []
     public var iconClicks: IconClicks?
     public var staticResource: [VastStaticResource] = []
-    public var iFrameResources: [URL] = []
-    public var htmlResources: [URL] = []
 }
 
 extension VastIcon {

--- a/VastClient/VastClient/models/XML schema/VastIcon.swift
+++ b/VastClient/VastClient/models/XML schema/VastIcon.swift
@@ -38,7 +38,7 @@ public struct VastIcon {
     public let apiFramework: String
     public let pxratio: Double
     
-    public var iconViewTracking: URL?
+    public var iconViewTracking: [URL] = []
     public var iconClicks: IconClicks?
     public var staticResource: [VastStaticResource] = []
     public var iFrameResources: [URL] = []

--- a/VastClient/VastClient/models/XML schema/VastLinearCreative.swift
+++ b/VastClient/VastClient/models/XML schema/VastLinearCreative.swift
@@ -42,7 +42,7 @@ fileprivate enum LinearCreativeAttribute: String, CaseIterable {
 // VAST/Ad/InLine/Creatives/Creative
 // VAST/Ad/Wrapper/Creatives/Creative
 public struct VastLinearCreative {
-    public let skipOffset: String?
+    public let skipOffset: String? // TODO: Consider changing to Int
     
     public var duration: Double? // Inline only
     public var adParameters: VastAdParameters? // Inline only

--- a/VastClient/VastClient/models/XML schema/VastTrackingEvent.swift
+++ b/VastClient/VastClient/models/XML schema/VastTrackingEvent.swift
@@ -22,8 +22,8 @@ public enum TrackingEventType: String {
     case resume
     case fullscreen
     case exitFullscreen
-    case expand
-    case collapse
+    case playerExpand
+    case playerCollapse
     case acceptInvitationLinear
     case closeLinear
     case skip

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -58,12 +58,6 @@ class VastXMLParser: NSObject {
 //    var currentCompanionCreative: VastCompanionCreative?
 
     var currentContent = ""
-
-    func parseTestFile(named filename: String, bundle: Bundle) throws -> VastModel {
-        let filepath = bundle.path(forResource: filename, ofType: "xml")!
-        let url = URL(fileURLWithPath: filepath)
-        return try parse(url: url)
-    }
     
     func parse(url: URL) throws -> VastModel {
         xmlParser = XMLParser(contentsOf: url)

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -150,6 +150,8 @@ extension VastXMLParser: XMLParserDelegate {
             case CreativeLinearElements.clickthrough, CreativeLinearElements.clicktracking, CreativeLinearElements.customclick:
                 guard let type = ClickType(rawValue: elementName) else { break }
                 currentVideoClick = VastVideoClick(type: type, attrDict: attributeDict)
+            case CreativeLinearElements.adParameters:
+                currentLinearCreative?.adParameters = VastAdParameters(attrDict: attributeDict)
             case CreativeLinearElements.mediafile:
                 currentMediaFile = VastMediaFile(attrDict: attributeDict)
             case CreativeLinearElements.interactiveCreativeFile:
@@ -210,7 +212,6 @@ extension VastXMLParser: XMLParserDelegate {
                     currentVastAd = nil
                 }
             case AdElements.inLine:
-                currentVastAd?.viewableImpression = currentViewableImpression
                 currentVastAd?.type = .inline
             case AdElements.wrapper:
                 if let wrapper = currentWrapper {
@@ -310,6 +311,8 @@ extension VastXMLParser: XMLParserDelegate {
                     currentVastAd?.creatives.append(creative)
                     currentCreative = nil
                 }
+                currentUniversalAdId = nil
+                currentCreativeExtension = nil
             case VastCreativeElements.universalAdId:
                 currentUniversalAdId?.uniqueCreativeId = currentContent
                 if let universalAdId = currentUniversalAdId {
@@ -368,6 +371,10 @@ extension VastXMLParser: XMLParserDelegate {
                     currentIcon?.staticResource.append(staticResource)
                 }
                 currentStaticResource = nil
+            case VastIconElements.iconViewTracking:
+                if let url = URL(string: currentContent) {
+                    currentIcon?.iconViewTracking.append(url)
+                }
             case IconClicksElements.iconClickThrough:
                 currentIcon?.iconClicks?.iconClickThrough = URL(string: currentContent)
             case IconClicksElements.iconClickTracking:

--- a/VastClient/VastClient/utils/http.swift
+++ b/VastClient/VastClient/utils/http.swift
@@ -16,9 +16,9 @@ func makeRequest(withUrl url: URL) {
     let task = session.dataTask(with: request) {(data, response, error) in
         DispatchQueue.global().async {
             #if DEBUG
-            NSLog("Completed request: \(request.debugDescription)")
+            print("Completed request: \(request.debugDescription)")
             if let error = error {
-                NSLog("Request \(request.debugDescription), finished with error: \(error)")
+                print("Request \(request.debugDescription), finished with error: \(error)")
                 return
             }
             #endif

--- a/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
@@ -11,7 +11,203 @@ import Foundation
 
 extension VastModel {
     static let fullVast4: VastModel = {
-        // TODO: fill in proper values from "TestFullVast4.xml" file
-        VastModel(version: "4.0", ads: [], errors: [])
+        let firstAd = getFirstAd()
+        let secondAd = getSecondAd()
+        let ads: [VastAd] = [firstAd, secondAd]
+        let errors: [URL] = []
+        return VastModel(version: "4.0", ads: ads, errors: errors)
     }()
+    
+    fileprivate static func getFirstAd() -> VastAd {
+        let type: AdType = AdType.wrapper
+        let id: String = "AdId1"
+        let sequence: Int? = 1
+        let conditionalAd: Bool? = false
+        let adSystem: VastAdSystem? = VastAdSystem(version: "1.0", system: "AdSystem1")
+    
+        let impressions: [VastImpression] = [VastImpression(id: "ImpressionId1", url: URL(string: "http://example.com/track/impression1")!), VastImpression(id: "ImpressionId2", url: URL(string: "http://example.com/track/impression2")!)]
+        
+        let firstAdVerification = VastVerification(vendor: URL(string: "http://vendor1.com"), viewableImpression: VastViewableImpression(id: "VerificationViewableImpression1", url: URL(string: "http://example.com/track/VerificationViewableImpression1"), viewable: [], notViewable: [], viewUndetermined: []), javaScriptResource: [], flashResources: [])
+        let secondAdVerification = VastVerification(vendor: URL(string: "http://vendor2.com"), viewableImpression: VastViewableImpression(id: "VerificationViewableImpression2", url: URL(string: "http://example.com/track/VerificationViewableImpression2"), viewable: [], notViewable: [], viewUndetermined: []), javaScriptResource: [], flashResources: [])
+        
+        let adVerifications: [VastVerification] = [firstAdVerification, secondAdVerification]
+        
+        let viewableURLs: [URL] = [URL(string: "http://example.com/track/viewable1")!, URL(string: "http://example.com/track/viewable2")!]
+        let notViewableURLs: [URL] = [URL(string: "http://example.com/track/notViewable1")!, URL(string: "http://example.com/track/notViewable2")!]
+        let viewUndeterminedURLs: [URL] = [URL(string: "http://example.com/track/viewUndetermined1")!, URL(string: "http://example.com/track/viewUndetermined2")!]
+        let viewableImpression: VastViewableImpression? = VastViewableImpression(id: "ViewableImpressionId1", url: nil, viewable: viewableURLs, notViewable: notViewableURLs, viewUndetermined: viewUndeterminedURLs)
+        
+        let pricing: VastPricing? = VastPricing(model: .cpc, currency: "EUR", pricing: 10)
+        let errors: [URL] = [URL(string: "http://example.com/error1")!, URL(string: "http://example.com/error2")!]
+        
+        
+        let videoClick1 = VastVideoClick(id: "VideoClickTrackingId1", type: .clickTracking, url: URL(string: "http://example.com/track/VideoClickTracking1"))
+        let videoClick2 = VastVideoClick(id: "VideoClickTrackingId2", type: .clickTracking, url: URL(string: "http://example.com/track/VideoClickTracking2"))
+        let videoClick3 = VastVideoClick(id: "VideoCustomClick1", type: .customClick, url: URL(string: "http://example.com/track/VideoCustomClick1"))
+        let videoClick4 = VastVideoClick(id: "VideoCustomClick2", type: .customClick, url: URL(string: "http://example.com/track/VideoCustomClick2"))
+        let videoClicks: [VastVideoClick] = [videoClick1, videoClick2, videoClick3, videoClick4]
+        
+        func tracking(hour: Int, minute: Int, second: Int, type: TrackingEventType, url: String) -> VastTrackingEvent {
+            return VastTrackingEvent(type: type, offset: Double(second + minute * 60 + hour * 3600) , url: URL(string: url), tracked: false)
+        }
+        
+        let trackingEvents: [VastTrackingEvent] = [
+            tracking(hour: 1, minute: 0, second: 1, type: .mute, url: "http://example.com/track/mute1"),
+            tracking(hour: 1, minute: 0, second: 2, type: .unmute, url: "http://example.com/track/unmute1"),
+            tracking(hour: 1, minute: 0, second: 3, type: .pause, url: "http://example.com/track/pause1"),
+            tracking(hour: 1, minute: 0, second: 4, type: .resume, url: "http://example.com/track/resume1"),
+            tracking(hour: 1, minute: 0, second: 5, type: .rewind, url: "http://example.com/track/rewind1"),
+            tracking(hour: 1, minute: 0, second: 6, type: .skip, url: "http://example.com/track/skip1"),
+            tracking(hour: 1, minute: 0, second: 7, type: .unknown, url: "http://example.com/track/playerExpand1"),
+            tracking(hour: 1, minute: 0, second: 8, type: .unknown, url: "http://example.com/track/playerCollapse1"),
+            tracking(hour: 1, minute: 0, second: 9, type: .acceptInvitationLinear, url: "http://example.com/track/acceptInvitationLinear1"),
+            tracking(hour: 1, minute: 0, second: 10, type: .unknown, url: "http://example.com/track/timeSpentViewing1"),
+            tracking(hour: 1, minute: 0, second: 11, type: .progress, url: "http://example.com/track/progress1"),
+            tracking(hour: 1, minute: 0, second: 12, type: .creativeView, url: "http://example.com/track/creativeView1"),
+            tracking(hour: 1, minute: 0, second: 13, type: .unknown, url: "http://example.com/track/acceptInvitation1"),
+            tracking(hour: 1, minute: 0, second: 14, type: .expand, url: "http://example.com/track/adExpand1"),
+            tracking(hour: 1, minute: 0, second: 15, type: .collapse, url: "http://example.com/track/adCollapse1"),
+            tracking(hour: 1, minute: 0, second: 16, type: .unknown, url: "http://example.com/track/minimize1"),
+            tracking(hour: 1, minute: 0, second: 17, type: .unknown, url: "http://example.com/track/close1"),
+            tracking(hour: 1, minute: 0, second: 18, type: .unknown, url: "http://example.com/track/overlayViewDuration1"),
+            tracking(hour: 1, minute: 0, second: 19, type: .unknown, url: "http://example.com/track/otherAdInteraction1"),
+            tracking(hour: 1, minute: 1, second: 1, type: .start, url: "http://example.com/track/start1"),
+            tracking(hour: 1, minute: 1, second: 2, type: .firstQuartile, url: "http://example.com/track/firstQuartile1"),
+            tracking(hour: 1, minute: 1, second: 3, type: .midpoint, url: "http://example.com/track/midpoint1"),
+            tracking(hour: 1, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile1"),
+            tracking(hour: 1, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete1"),
+        ]
+        let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking3")!, URL(string: "http://example.com/track/IconViewTracking4")!]
+        let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough1"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId3", url: URL(string: "http://example.com/track/IconClickTracking3")), VastIconClickTracking(id: "IconClickTrackingId4", url: URL(string: "http://example.com/track/IconClickTracking4"))])
+        let staticResource: [VastStaticResource] = [VastStaticResource(creativeType: "StaticResourceCreativeType3", url: URL(string: "http://example.com/StaticResource3")!), VastStaticResource(creativeType: "StaticResourceCreativeType4", url: URL(string: "http://example.com/StaticResource4"))]
+        let iFrameResources: [URL] = [URL(string: "http://example.com/IFrameResource3")!, URL(string: "http://example.com/IFrameResource4")!]
+        let htmlResources: [URL] = [URL(string: "http://example.com/HTMLResource3")!, URL(string: "http://example.com/HTMLResource4")!]
+        
+        let mediaFile: [VastMediaFile] = []
+        let interactiveCreativeFile: [VastInteractiveCreativeFile] = []
+        let mediaFiles = VastMediaFiles(mediaFiles: mediaFile, interactiveCreativeFile: interactiveCreativeFile)
+        
+        let icons: [VastIcon] = [VastIcon(program: "program", width: 11, height: 10, xPosition: "20", yPosition: "21", duration: 5, offset: 6, apiFramework: "IconApiFramework1", pxratio: 1.1, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource, iFrameResources: iFrameResources, htmlResources: htmlResources)]
+        let firstLinear = VastLinearCreative(skipOffset: "00:00:10", duration: nil, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
+        
+        let firstCreative = VastCreative(id: "CreativeId1", adId: "CreativeAdId1", sequence: 1, apiFramework: "CreativeApiFramework1", universalAdId: nil, creativeExtensions: [], linear: firstLinear)
+        let secondCreative = VastCreative(id: "CreativeId2", adId: "CreativeAdId2", sequence: 2, apiFramework: "CreativeApiFramework2", universalAdId: nil, creativeExtensions: [], linear: nil)
+        
+        let creatives: [VastCreative] = [firstCreative ,secondCreative]
+        let extensions: [VastExtension] = [VastExtension(type: "ExtensionType1", creativeParameters: []), VastExtension(type: "ExtensionType2", creativeParameters: [])]
+        let adTitle: String? = nil
+        let adCategories: [VastAdCategory] = []
+        let description: String? = nil
+        let advertiser: String? = nil
+        let surveys: [VastSurvey] = []
+        
+        let followAdditionalWrappers: Bool? = true
+        let allowMultipleAds: Bool? = true
+        let fallbackOnNoAd: Bool? = false
+        let adTagUri: URL? = URL(string: "http://example.com/VASTAdTagURI")
+        let wrapper: VastWrapper? = VastWrapper(followAdditionalWrappers: followAdditionalWrappers, allowMultipleAds: allowMultipleAds, fallbackOnNoAd: fallbackOnNoAd, adTagUri: adTagUri)
+        
+        return VastAd(type: type, id: id, sequence: sequence, conditionalAd: conditionalAd, adSystem: adSystem, impressions: impressions, adVerifications: adVerifications, viewableImpression: viewableImpression, pricing: pricing, errors: errors, creatives: creatives, extensions: extensions, adTitle: adTitle, adCategories: adCategories, description: description, advertiser: advertiser, surveys: surveys, wrapper: wrapper)
+    }
+    
+    fileprivate static func getSecondAd() -> VastAd {
+        let type: AdType = AdType.inline
+        let id: String = "AdId2"
+        let sequence: Int? = 2
+        let conditionalAd: Bool? = true
+        let adSystem: VastAdSystem? = VastAdSystem(version: "2.0", system: "AdSystem2")
+        
+        let errors: [URL] = [URL(string: "http://example.com/error3")!, URL(string: "http://example.com/error4")!]
+        
+        let pricing: VastPricing? = VastPricing(model: .cpm, currency: "CZK", pricing: 99.90)
+        
+        let impressions: [VastImpression] = [VastImpression(id: "ImpressionId3", url: URL(string: "http://example.com/track/impression3")!), VastImpression(id: "ImpressionId4", url: URL(string: "http://example.com/track/impression4")!)]
+        
+        let firstAdVerification = VastVerification(vendor: URL(string: "http://vendor3.com"), viewableImpression: VastViewableImpression(id: "VerificationViewableImpression3", url: URL(string: "http://example.com/track/VerificationViewableImpression3"), viewable: [], notViewable: [], viewUndetermined: []), javaScriptResource: [VastResource(apiFramework: "JavaScriptResourceApiFramework1", url: URL(string: "http://example.com/track/JavaScriptResource1")), VastResource(apiFramework: "JavaScriptResourceApiFramework2", url: URL(string: "http://example.com/track/JavaScriptResource2"))], flashResources: [VastResource(apiFramework: "FlashResourceApiFramework1", url: URL(string: "http://example.com/track/FlashResource1")), VastResource(apiFramework: "FlashResourceApiFramework2", url: URL(string: "http://example.com/track/FlashResource2"))])
+        let secondAdVerification = VastVerification(vendor: URL(string: "http://vendor4.com"), viewableImpression: VastViewableImpression(id: "VerificationViewableImpression4", url: URL(string: "http://example.com/track/VerificationViewableImpression4"), viewable: [], notViewable: [], viewUndetermined: []), javaScriptResource: [VastResource(apiFramework: "JavaScriptResourceApiFramework3", url: URL(string: "http://example.com/track/JavaScriptResource3")), VastResource(apiFramework: "JavaScriptResourceApiFramework4", url: URL(string: "http://example.com/track/JavaScriptResource4"))], flashResources: [VastResource(apiFramework: "FlashResourceApiFramework3", url: URL(string: "http://example.com/track/FlashResource3")), VastResource(apiFramework: "FlashResourceApiFramework4", url: URL(string: "http://example.com/track/FlashResource4"))])
+        
+        let adVerifications: [VastVerification] = [firstAdVerification, secondAdVerification]
+        
+        let viewableURLs: [URL] = [URL(string: "http://example.com/track/viewable3")!, URL(string: "http://example.com/track/viewable4")!]
+        let notViewableURLs: [URL] = [URL(string: "http://example.com/track/notViewable3")!, URL(string: "http://example.com/track/notViewable4")!]
+        let viewUndeterminedURLs: [URL] = [URL(string: "http://example.com/track/viewUndetermined3")!, URL(string: "http://example.com/track/viewUndetermined4")!]
+        let viewableImpression: VastViewableImpression? = VastViewableImpression(id: "ViewableImpressionId2", url: nil, viewable: viewableURLs, notViewable: notViewableURLs, viewUndetermined: viewUndeterminedURLs)
+        
+        
+        let videoClick1 = VastVideoClick(id: "VideoClickTrackingId3", type: .clickTracking, url: URL(string: "http://example.com/track/VideoClickTracking3"))
+        let videoClick2 = VastVideoClick(id: "VideoClickTrackingId4", type: .clickTracking, url: URL(string: "http://example.com/track/VideoClickTracking4"))
+        let videoClick3 = VastVideoClick(id: "VideoCustomClick3", type: .customClick, url: URL(string: "http://example.com/track/VideoCustomClick3"))
+        let videoClick4 = VastVideoClick(id: "VideoCustomClick4", type: .customClick, url: URL(string: "http://example.com/track/VideoCustomClick4"))
+        let videoClick5 = VastVideoClick(id: "ClickThrough", type: .clickThrough, url: URL(string: "http://example.com/track/videoClickThrough"))
+        let videoClicks: [VastVideoClick] = [videoClick1, videoClick2, videoClick3, videoClick4, videoClick5]
+        
+        func tracking(hour: Int, minute: Int, second: Int, type: TrackingEventType, url: String) -> VastTrackingEvent {
+            return VastTrackingEvent(type: type, offset: Double(second + minute * 60 + hour * 3600) , url: URL(string: url), tracked: false)
+        }
+        
+        let trackingEvents: [VastTrackingEvent] = [
+            tracking(hour: 4, minute: 0, second: 1, type: .mute, url: "http://example.com/track/mute4"),
+            tracking(hour: 4, minute: 0, second: 2, type: .unmute, url: "http://example.com/track/unmute4"),
+            tracking(hour: 4, minute: 0, second: 3, type: .pause, url: "http://example.com/track/pause4"),
+            tracking(hour: 4, minute: 0, second: 4, type: .resume, url: "http://example.com/track/resume4"),
+            tracking(hour: 4, minute: 0, second: 5, type: .rewind, url: "http://example.com/track/rewind4"),
+            tracking(hour: 4, minute: 0, second: 6, type: .skip, url: "http://example.com/track/skip4"),
+            tracking(hour: 4, minute: 0, second: 7, type: .unknown, url: "http://example.com/track/playerExpand4"),
+            tracking(hour: 4, minute: 0, second: 8, type: .unknown, url: "http://example.com/track/playerCollapse4"),
+            tracking(hour: 4, minute: 0, second: 9, type: .acceptInvitationLinear, url: "http://example.com/track/acceptInvitationLinear4"),
+            tracking(hour: 4, minute: 0, second: 10, type: .unknown, url: "http://example.com/track/timeSpentViewing4"),
+            tracking(hour: 4, minute: 0, second: 11, type: .progress, url: "http://example.com/track/progress4"),
+            tracking(hour: 4, minute: 0, second: 12, type: .creativeView, url: "http://example.com/track/creativeView4"),
+            tracking(hour: 4, minute: 0, second: 13, type: .unknown, url: "http://example.com/track/acceptInvitation4"),
+            tracking(hour: 4, minute: 0, second: 14, type: .expand, url: "http://example.com/track/adExpand4"),
+            tracking(hour: 4, minute: 0, second: 15, type: .collapse, url: "http://example.com/track/adCollapse4"),
+            tracking(hour: 4, minute: 0, second: 16, type: .unknown, url: "http://example.com/track/minimize4"),
+            tracking(hour: 4, minute: 0, second: 17, type: .unknown, url: "http://example.com/track/close4"),
+            tracking(hour: 4, minute: 0, second: 18, type: .unknown, url: "http://example.com/track/overlayViewDuration4"),
+            tracking(hour: 4, minute: 0, second: 19, type: .unknown, url: "http://example.com/track/otherAdInteraction4"),
+            tracking(hour: 4, minute: 1, second: 1, type: .start, url: "http://example.com/track/start4"),
+            tracking(hour: 4, minute: 1, second: 2, type: .firstQuartile, url: "http://example.com/track/firstQuartile4"),
+            tracking(hour: 4, minute: 1, second: 3, type: .midpoint, url: "http://example.com/track/midpoint4"),
+            tracking(hour: 4, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile4"),
+            tracking(hour: 4, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete4"),
+            ]
+        let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking3")!, URL(string: "http://example.com/track/IconViewTracking4")!]
+        let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough2"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId5", url: URL(string: "http://example.com/track/IconClickTracking5")), VastIconClickTracking(id: "IconClickTrackingId6", url: URL(string: "http://example.com/track/IconClickTracking6"))])
+        let staticResource: [VastStaticResource] = [VastStaticResource(creativeType: "StaticResourceCreativeType7", url: URL(string: "http://example.com/StaticResource7")!), VastStaticResource(creativeType: "StaticResourceCreativeType8", url: URL(string: "http://example.com/StaticResource8"))]
+        let iFrameResources: [URL] = [URL(string: "http://example.com/IFrameResource7")!, URL(string: "http://example.com/IFrameResource8")!]
+        let htmlResources: [URL] = [URL(string: "http://example.com/HTMLResource7")!, URL(string: "http://example.com/HTMLResource8")!]
+        
+        let mediaFile1 = VastMediaFile(delivery: "progressive", type: "video/mp4", width: "100", height: "50", codec: "H.246", id: "1", bitrate: 100, minBitrate: 50, maxBitrate: 200, scalable: true, maintainAspectRatio: true, apiFramework: "MediaFileApiFramework1", url: URL(string: "http://example.com/video.mp4"))
+        let mediaFile2 = VastMediaFile(delivery: "streaming", type: "video/mp4", width: "101", height: "51", codec: "H.247", id: "2", bitrate: 101, minBitrate: 51, maxBitrate: 201, scalable: false, maintainAspectRatio: false, apiFramework: "MediaFileApiFramework2", url: URL(string: "http://example.com/video1.mp4"))
+        let mediaFile: [VastMediaFile] = [mediaFile1, mediaFile2]
+        
+        let interactiveCreativeFile1 = VastInteractiveCreativeFile(type: "text/html", apiFramework: "InteractiveCreativeFileApiFramework1", url: URL(string: "http://example.com/InteractiveCreativeFile1"))
+        let interactiveCreativeFile2 = VastInteractiveCreativeFile(type: "text/text", apiFramework: "InteractiveCreativeFileApiFramework2", url: URL(string: "http://example.com/InteractiveCreativeFile2"))
+        let interactiveCreativeFile: [VastInteractiveCreativeFile] = [interactiveCreativeFile1, interactiveCreativeFile2]
+        let mediaFiles = VastMediaFiles(mediaFiles: mediaFile, interactiveCreativeFile: interactiveCreativeFile)
+        
+        let icons: [VastIcon] = [VastIcon(program: "program2", width: 211, height: 210, xPosition: "220", yPosition: "221", duration: 125, offset: 126, apiFramework: "IconApiFramework2", pxratio: 1.2, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource, iFrameResources: iFrameResources, htmlResources: htmlResources)]
+        let adParameters = VastAdParameters(xmlEncoded: "true", content: "http://example.com/AdParameters3")
+        let firstLinear = VastLinearCreative(skipOffset: "00:00:08", duration: 70, adParameters: adParameters, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
+        
+        
+        let creativeExtensions: [VastCreativeExtension] = [VastCreativeExtension(mimeType: "CreativeExtensionType5", content: ""), VastCreativeExtension(mimeType: "CreativeExtensionType6", content: "")]
+        
+        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: nil, creativeExtensions: creativeExtensions, linear: nil)
+        let secondCreative = VastCreative(id: "CreativeId4", adId: "CreativeAdId4", sequence: 4, apiFramework: "CreativeApiFramework4", universalAdId: nil, creativeExtensions: [], linear: firstLinear)
+        
+        let creatives: [VastCreative] = [firstCreative ,secondCreative]
+        let extensions: [VastExtension] = [VastExtension(type: "ExtensionType3", creativeParameters: []), VastExtension(type: "ExtensionType4", creativeParameters: [])]
+        let adTitle: String? = "AdTitle"
+        let adCategories: [VastAdCategory] = [VastAdCategory(authority: URL(string: "CategoryAuthority1"), category: "Category1"), VastAdCategory(authority: URL(string: "CategoryAuthority2"), category: "Category2")]
+        let description: String? = "Description"
+        let advertiser: String? = "Advertiser"
+        let surveys: [VastSurvey] = [VastSurvey(type: "text/html", survey: URL(string: "http://example.com/survey"))]
+        
+        let wrapper: VastWrapper? = nil
+        
+        return VastAd(type: type, id: id, sequence: sequence, conditionalAd: conditionalAd, adSystem: adSystem, impressions: impressions, adVerifications: adVerifications, viewableImpression: viewableImpression, pricing: pricing, errors: errors, creatives: creatives, extensions: extensions, adTitle: adTitle, adCategories: adCategories, description: description, advertiser: advertiser, surveys: surveys, wrapper: wrapper)
+        
+    }
+    
 }

--- a/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
@@ -80,14 +80,12 @@ extension VastModel {
         let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking3")!, URL(string: "http://example.com/track/IconViewTracking4")!]
         let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough1"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId3", url: URL(string: "http://example.com/track/IconClickTracking3")), VastIconClickTracking(id: "IconClickTrackingId4", url: URL(string: "http://example.com/track/IconClickTracking4"))])
         let staticResource: [VastStaticResource] = [VastStaticResource(creativeType: "StaticResourceCreativeType3", url: URL(string: "http://example.com/StaticResource3")!), VastStaticResource(creativeType: "StaticResourceCreativeType4", url: URL(string: "http://example.com/StaticResource4"))]
-        let iFrameResources: [URL] = [URL(string: "http://example.com/IFrameResource3")!, URL(string: "http://example.com/IFrameResource4")!]
-        let htmlResources: [URL] = [URL(string: "http://example.com/HTMLResource3")!, URL(string: "http://example.com/HTMLResource4")!]
         
         let mediaFile: [VastMediaFile] = []
         let interactiveCreativeFile: [VastInteractiveCreativeFile] = []
         let mediaFiles = VastMediaFiles(mediaFiles: mediaFile, interactiveCreativeFile: interactiveCreativeFile)
         
-        let icons: [VastIcon] = [VastIcon(program: "program", width: 11, height: 10, xPosition: "20", yPosition: "21", duration: 5, offset: 6, apiFramework: "IconApiFramework1", pxratio: 1.1, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource, iFrameResources: iFrameResources, htmlResources: htmlResources)]
+        let icons: [VastIcon] = [VastIcon(program: "program", width: 11, height: 10, xPosition: "20", yPosition: "21", duration: 5, offset: 6, apiFramework: "IconApiFramework1", pxratio: 1.1, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource)]
         let firstLinear = VastLinearCreative(skipOffset: "00:00:10", duration: nil, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
         
         let firstCreative = VastCreative(id: "CreativeId1", adId: "CreativeAdId1", sequence: 1, apiFramework: "CreativeApiFramework1", universalAdId: nil, creativeExtensions: [], linear: firstLinear)
@@ -174,8 +172,6 @@ extension VastModel {
         let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking3")!, URL(string: "http://example.com/track/IconViewTracking4")!]
         let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough2"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId5", url: URL(string: "http://example.com/track/IconClickTracking5")), VastIconClickTracking(id: "IconClickTrackingId6", url: URL(string: "http://example.com/track/IconClickTracking6"))])
         let staticResource: [VastStaticResource] = [VastStaticResource(creativeType: "StaticResourceCreativeType7", url: URL(string: "http://example.com/StaticResource7")!), VastStaticResource(creativeType: "StaticResourceCreativeType8", url: URL(string: "http://example.com/StaticResource8"))]
-        let iFrameResources: [URL] = [URL(string: "http://example.com/IFrameResource7")!, URL(string: "http://example.com/IFrameResource8")!]
-        let htmlResources: [URL] = [URL(string: "http://example.com/HTMLResource7")!, URL(string: "http://example.com/HTMLResource8")!]
         
         let mediaFile1 = VastMediaFile(delivery: "progressive", type: "video/mp4", width: "100", height: "50", codec: "H.246", id: "1", bitrate: 100, minBitrate: 50, maxBitrate: 200, scalable: true, maintainAspectRatio: true, apiFramework: "MediaFileApiFramework1", url: URL(string: "http://example.com/video.mp4"))
         let mediaFile2 = VastMediaFile(delivery: "streaming", type: "video/mp4", width: "101", height: "51", codec: "H.247", id: "2", bitrate: 101, minBitrate: 51, maxBitrate: 201, scalable: false, maintainAspectRatio: false, apiFramework: "MediaFileApiFramework2", url: URL(string: "http://example.com/video1.mp4"))
@@ -186,7 +182,7 @@ extension VastModel {
         let interactiveCreativeFile: [VastInteractiveCreativeFile] = [interactiveCreativeFile1, interactiveCreativeFile2]
         let mediaFiles = VastMediaFiles(mediaFiles: mediaFile, interactiveCreativeFile: interactiveCreativeFile)
         
-        let icons: [VastIcon] = [VastIcon(program: "program2", width: 211, height: 210, xPosition: "220", yPosition: "221", duration: 125, offset: 126, apiFramework: "IconApiFramework2", pxratio: 1.2, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource, iFrameResources: iFrameResources, htmlResources: htmlResources)]
+        let icons: [VastIcon] = [VastIcon(program: "program2", width: 211, height: 210, xPosition: "220", yPosition: "221", duration: 125, offset: 126, apiFramework: "IconApiFramework2", pxratio: 1.2, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource)]
         let adParameters = VastAdParameters(xmlEncoded: "true", content: "http://example.com/AdParameters3")
         let firstLinear = VastLinearCreative(skipOffset: "00:00:08", duration: 70, adParameters: adParameters, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
         

--- a/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
@@ -58,15 +58,15 @@ extension VastModel {
             tracking(hour: 1, minute: 0, second: 4, type: .resume, url: "http://example.com/track/resume1"),
             tracking(hour: 1, minute: 0, second: 5, type: .rewind, url: "http://example.com/track/rewind1"),
             tracking(hour: 1, minute: 0, second: 6, type: .skip, url: "http://example.com/track/skip1"),
-            tracking(hour: 1, minute: 0, second: 7, type: .unknown, url: "http://example.com/track/playerExpand1"),
-            tracking(hour: 1, minute: 0, second: 8, type: .unknown, url: "http://example.com/track/playerCollapse1"),
+            tracking(hour: 1, minute: 0, second: 7, type: .playerExpand, url: "http://example.com/track/playerExpand1"),
+            tracking(hour: 1, minute: 0, second: 8, type: .playerCollapse, url: "http://example.com/track/playerCollapse1"),
             tracking(hour: 1, minute: 0, second: 9, type: .acceptInvitationLinear, url: "http://example.com/track/acceptInvitationLinear1"),
             tracking(hour: 1, minute: 0, second: 10, type: .unknown, url: "http://example.com/track/timeSpentViewing1"),
             tracking(hour: 1, minute: 0, second: 11, type: .progress, url: "http://example.com/track/progress1"),
             tracking(hour: 1, minute: 0, second: 12, type: .creativeView, url: "http://example.com/track/creativeView1"),
             tracking(hour: 1, minute: 0, second: 13, type: .unknown, url: "http://example.com/track/acceptInvitation1"),
-            tracking(hour: 1, minute: 0, second: 14, type: .expand, url: "http://example.com/track/adExpand1"),
-            tracking(hour: 1, minute: 0, second: 15, type: .collapse, url: "http://example.com/track/adCollapse1"),
+            tracking(hour: 1, minute: 0, second: 14, type: .unknown, url: "http://example.com/track/adExpand1"),
+            tracking(hour: 1, minute: 0, second: 15, type: .unknown, url: "http://example.com/track/adCollapse1"),
             tracking(hour: 1, minute: 0, second: 16, type: .unknown, url: "http://example.com/track/minimize1"),
             tracking(hour: 1, minute: 0, second: 17, type: .unknown, url: "http://example.com/track/close1"),
             tracking(hour: 1, minute: 0, second: 18, type: .unknown, url: "http://example.com/track/overlayViewDuration1"),
@@ -150,15 +150,15 @@ extension VastModel {
             tracking(hour: 4, minute: 0, second: 4, type: .resume, url: "http://example.com/track/resume4"),
             tracking(hour: 4, minute: 0, second: 5, type: .rewind, url: "http://example.com/track/rewind4"),
             tracking(hour: 4, minute: 0, second: 6, type: .skip, url: "http://example.com/track/skip4"),
-            tracking(hour: 4, minute: 0, second: 7, type: .unknown, url: "http://example.com/track/playerExpand4"),
-            tracking(hour: 4, minute: 0, second: 8, type: .unknown, url: "http://example.com/track/playerCollapse4"),
+            tracking(hour: 4, minute: 0, second: 7, type: .playerExpand, url: "http://example.com/track/playerExpand4"),
+            tracking(hour: 4, minute: 0, second: 8, type: .playerCollapse, url: "http://example.com/track/playerCollapse4"),
             tracking(hour: 4, minute: 0, second: 9, type: .acceptInvitationLinear, url: "http://example.com/track/acceptInvitationLinear4"),
             tracking(hour: 4, minute: 0, second: 10, type: .unknown, url: "http://example.com/track/timeSpentViewing4"),
             tracking(hour: 4, minute: 0, second: 11, type: .progress, url: "http://example.com/track/progress4"),
             tracking(hour: 4, minute: 0, second: 12, type: .creativeView, url: "http://example.com/track/creativeView4"),
             tracking(hour: 4, minute: 0, second: 13, type: .unknown, url: "http://example.com/track/acceptInvitation4"),
-            tracking(hour: 4, minute: 0, second: 14, type: .expand, url: "http://example.com/track/adExpand4"),
-            tracking(hour: 4, minute: 0, second: 15, type: .collapse, url: "http://example.com/track/adCollapse4"),
+            tracking(hour: 4, minute: 0, second: 14, type: .unknown, url: "http://example.com/track/adExpand4"),
+            tracking(hour: 4, minute: 0, second: 15, type: .unknown, url: "http://example.com/track/adCollapse4"),
             tracking(hour: 4, minute: 0, second: 16, type: .unknown, url: "http://example.com/track/minimize4"),
             tracking(hour: 4, minute: 0, second: 17, type: .unknown, url: "http://example.com/track/close4"),
             tracking(hour: 4, minute: 0, second: 18, type: .unknown, url: "http://example.com/track/overlayViewDuration4"),
@@ -169,7 +169,7 @@ extension VastModel {
             tracking(hour: 4, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile4"),
             tracking(hour: 4, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete4"),
             ]
-        let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking3")!, URL(string: "http://example.com/track/IconViewTracking4")!]
+        let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking5")!, URL(string: "http://example.com/track/IconViewTracking6")!]
         let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough2"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId5", url: URL(string: "http://example.com/track/IconClickTracking5")), VastIconClickTracking(id: "IconClickTrackingId6", url: URL(string: "http://example.com/track/IconClickTracking6"))])
         let staticResource: [VastStaticResource] = [VastStaticResource(creativeType: "StaticResourceCreativeType7", url: URL(string: "http://example.com/StaticResource7")!), VastStaticResource(creativeType: "StaticResourceCreativeType8", url: URL(string: "http://example.com/StaticResource8"))]
         
@@ -189,8 +189,8 @@ extension VastModel {
         
         let creativeExtensions: [VastCreativeExtension] = [VastCreativeExtension(mimeType: "CreativeExtensionType5", content: ""), VastCreativeExtension(mimeType: "CreativeExtensionType6", content: "")]
         
-        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: nil, creativeExtensions: creativeExtensions, linear: nil)
-        let secondCreative = VastCreative(id: "CreativeId4", adId: "CreativeAdId4", sequence: 4, apiFramework: "CreativeApiFramework4", universalAdId: nil, creativeExtensions: [], linear: firstLinear)
+        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId1"), creativeExtensions: creativeExtensions, linear: nil)
+        let secondCreative = VastCreative(id: "CreativeId4", adId: "CreativeAdId4", sequence: 4, apiFramework: "CreativeApiFramework4", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId2"), creativeExtensions: [], linear: firstLinear)
         
         let creatives: [VastCreative] = [firstCreative ,secondCreative]
         let extensions: [VastExtension] = [VastExtension(type: "ExtensionType3", creativeParameters: []), VastExtension(type: "ExtensionType4", creativeParameters: [])]
@@ -199,6 +199,7 @@ extension VastModel {
         let description: String? = "Description"
         let advertiser: String? = "Advertiser"
         let surveys: [VastSurvey] = [VastSurvey(type: "text/html", survey: URL(string: "http://example.com/survey"))]
+        
         
         let wrapper: VastWrapper? = nil
         

--- a/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
@@ -38,9 +38,9 @@ extension VastModel {
         
         let icon1Clicks = IconClicks(iconClickThrough: URL(string: "https://iabtechlab.com")!, iconClickTracking: [VastIconClickTracking(id: "iconclick", url: URL(string: "https://iabtechlab.com")!)])
         let icon1StaticResources: [VastStaticResource] = [VastStaticResource(creativeType: "image/jpg", url: URL(string: "https://images-nl.ott.kaltura.com/Service.svc/GetImage/p/436/entry_id/422ec4ffe19d4435aaca092dc83bae0c_12/version/0/quality/85/width/118/height/15/"))]
-        let icon1 = VastIcon(program: "programName", width: 118, height: 15, xPosition: "left", yPosition: "top", duration: 0, offset: 5, apiFramework: "", pxratio: 1, iconViewTracking: nil, iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
+        let icon1 = VastIcon(program: "programName", width: 118, height: 15, xPosition: "left", yPosition: "top", duration: 0, offset: 5, apiFramework: "", pxratio: 1, iconViewTracking: [], iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
         
-        let icon2 = VastIcon(program: "programName2", width: 118, height: 15, xPosition: "100", yPosition: "100", duration: 0, offset: 0, apiFramework: "", pxratio: 1, iconViewTracking: nil, iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
+        let icon2 = VastIcon(program: "programName2", width: 118, height: 15, xPosition: "100", yPosition: "100", duration: 0, offset: 0, apiFramework: "", pxratio: 1, iconViewTracking: [], iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
         
         let icons: [VastIcon] = [icon1, icon2]
         

--- a/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
@@ -38,9 +38,9 @@ extension VastModel {
         
         let icon1Clicks = IconClicks(iconClickThrough: URL(string: "https://iabtechlab.com")!, iconClickTracking: [VastIconClickTracking(id: "iconclick", url: URL(string: "https://iabtechlab.com")!)])
         let icon1StaticResources: [VastStaticResource] = [VastStaticResource(creativeType: "image/jpg", url: URL(string: "https://images-nl.ott.kaltura.com/Service.svc/GetImage/p/436/entry_id/422ec4ffe19d4435aaca092dc83bae0c_12/version/0/quality/85/width/118/height/15/"))]
-        let icon1 = VastIcon(program: "programName", width: 118, height: 15, xPosition: "left", yPosition: "top", duration: 0, offset: 5, apiFramework: "", pxratio: 1, iconViewTracking: [], iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
+        let icon1 = VastIcon(program: "programName", width: 118, height: 15, xPosition: "left", yPosition: "top", duration: 0, offset: 5, apiFramework: "", pxratio: 1, iconViewTracking: [], iconClicks: icon1Clicks, staticResource: icon1StaticResources)
         
-        let icon2 = VastIcon(program: "programName2", width: 118, height: 15, xPosition: "100", yPosition: "100", duration: 0, offset: 0, apiFramework: "", pxratio: 1, iconViewTracking: [], iconClicks: icon1Clicks, staticResource: icon1StaticResources, iFrameResources: [], htmlResources: [])
+        let icon2 = VastIcon(program: "programName2", width: 118, height: 15, xPosition: "100", yPosition: "100", duration: 0, offset: 0, apiFramework: "", pxratio: 1, iconViewTracking: [], iconClicks: icon1Clicks, staticResource: icon1StaticResources)
         
         let icons: [VastIcon] = [icon1, icon2]
         
@@ -59,7 +59,9 @@ extension VastModel {
         
         let adVerifications: [VastVerification] = [vastVerification1, vastVerification2]
         
-        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: adVerifications, viewableImpression: nil, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: categories, description: nil, advertiser: nil, surveys: [], wrapper: nil)
+        let viewableImpression = VastViewableImpression(id: "VImpression-ID", url: nil, viewable: [URL(string: "http://example.com/track/Viewable")!], notViewable: [], viewUndetermined: [URL(string: "http://example.com/track/ViewUndetermined")!])
+        
+        let ad = VastAd(type: .inline, id: "20001", sequence: 1, conditionalAd: nil, adSystem: adSystem, impressions: [impressions], adVerifications: adVerifications, viewableImpression: viewableImpression, pricing: pricing, errors: errors, creatives: [creative], extensions: extensions, adTitle: "iabtechlab video ad", adCategories: categories, description: nil, advertiser: nil, surveys: [], wrapper: nil)
         
         return VastModel(version: "4.0", ads: [ad], errors: [])
     }()

--- a/VastClient/VastClientTests/Assets/Vast4/TestFullVast4.xml
+++ b/VastClient/VastClientTests/Assets/Vast4/TestFullVast4.xml
@@ -56,16 +56,6 @@
                             <CompanionClickThrough>http://example.com/track/CompanionClickThrough1</CompanionClickThrough>
                             <CompanionClickTracking id="CompanionClickTrackingId1">http://example.com/track/CompanionClickTracking1</CompanionClickTracking>
                             <CompanionClickTracking id="CompanionClickTrackingId2"><![CDATA[http://example.com/track/CompanionClickTracking2]]></CompanionClickTracking>
-                            <CreativeExtensions>
-                                <CreativeExtension type="CreativeExtensionType1">
-                                    <any>any31</any>
-                                    <any>any32</any>
-                                </CreativeExtension>
-                                <CreativeExtension type="CreativeExtensionType2">
-                                    <any>any41</any>
-                                    <any>any42</any>
-                                </CreativeExtension>
-                            </CreativeExtensions>
                             <TrackingEvents>
                                 <Tracking offset="00:00:01" event="mute">http://example.com/track/mute</Tracking>
                                 <Tracking offset="00:00:02" event="unmute">http://example.com/track/unmute</Tracking>
@@ -265,16 +255,6 @@
                             <CompanionClickThrough>http://example.com/track/CompanionClickThrough2</CompanionClickThrough>
                             <CompanionClickTracking id="CompanionClickTrackingId3">http://example.com/track/CompanionClickTracking3</CompanionClickTracking>
                             <CompanionClickTracking id="CompanionClickTrackingId4"><![CDATA[http://example.com/track/CompanionClickTracking4]]></CompanionClickTracking>
-                            <CreativeExtensions>
-                                <CreativeExtension type="CreativeExtensionType3">
-                                    <any>any71</any>
-                                    <any>any72</any>
-                                </CreativeExtension>
-                                <CreativeExtension type="CreativeExtensionType4">
-                                    <any>any81</any>
-                                    <any>any82</any>
-                                </CreativeExtension>
-                            </CreativeExtensions>
                             <TrackingEvents>
                                 <Tracking offset="03:00:01" event="mute">http://example.com/track/mute3</Tracking>
                                 <Tracking offset="03:00:02" event="unmute">http://example.com/track/unmute3</Tracking>

--- a/VastClient/VastClientTests/VastXMLParserTests.swift
+++ b/VastClient/VastClientTests/VastXMLParserTests.swift
@@ -100,6 +100,11 @@ class VastXMLParserTests: XCTestCase {
         XCTAssertEqual(model.errors.count, 0)
     }
     
+    func test_fullVast4File() {
+        let model = self.loadVastFile(named: "TestFullVast4")
+        XCTAssertEqual(model, VastModel.fullVast4)
+    }
+    
     func test_inlineLinearIcons() {
         let model = self.loadVastFile(named: "Inline_linear_icons-test")
         XCTAssertEqual(model, VastModel.inlineLinearIcons)

--- a/VastClientWrapper/VastClientWrapper/VastExample.swift
+++ b/VastClientWrapper/VastClientWrapper/VastExample.swift
@@ -19,6 +19,7 @@ class VastExample {
     private var vastTracker: VastTracker?
     private var fakePlayheadProgressTimer: Timer?
     private var playhead = 123456.0
+    private var currentAdEndTime: TimeInterval?
 
     init() {
         makeVastRequest()
@@ -27,75 +28,88 @@ class VastExample {
     private func makeVastRequest() {
         let urlStr = fw_test
         guard let url = URL(string: urlStr) else { return }
-        do {
-            let start = Date()
-            let vastModel = try vastClient.parseVast(withContentsOf: url)
+        let start = Date()
+        vastClient.parseVast(withContentsOf: url) { [weak self] vastModel, error in
             print("Took \(-1 * start.timeIntervalSinceNow) seconds to parse vast document")
-            trackAd(vastModel)
-        } catch VastError.invalidXMLDocument {
-            print("Error: Invalid XML document")
-        } catch VastError.invalidVASTDocument {
-            print("Error: Invalid Vast Document")
-        } catch VastError.unableToCreateXMLParser {
-            print("Error: Unable to Create XML Parser")
-        } catch VastError.unableToParseDocument {
-            print("Error: Unable to Parse Vast Document")
-        } catch {
-            print("Error: unexpected error ...")
+            if let error = error as? VastError {
+                switch error {
+                case .invalidXMLDocument:
+                    print("Error: Invalid XML document")
+                case .invalidVASTDocument:
+                    print("Error: Invalid Vast Document")
+                case .unableToCreateXMLParser:
+                    print("Error: Unable to Create XML Parser")
+                case .unableToParseDocument:
+                    print("Error: Unable to Parse Vast Document")
+                default:
+                    print("Error: unexpected error ...")
+                }
+                return
+            }
+            
+            guard let vastModel = vastModel else {
+                print("Error: unexpected error ...")
+                return
+            }
+            self?.trackAd(vastModel)
         }
     }
-
-}
-
-extension VastExample: VastTrackerDelegate {
-
-    func trackAd(_ ad: VastModel) {
+    
+    private func trackAd(_ ad: VastModel) {
         let delay = 0.1
         vastTracker = VastTracker(id: "test", vastModel: ad, startTime: 123456.0, delegate: self)
-
+        
         guard let tracker = vastTracker else { return }
         fakePlayheadProgressTimer = setInterval(delay) { [weak self] _ in
             guard var playhead = self?.playhead else { return }
             playhead += delay
             self?.playhead = playhead
+            
             do {
-                try tracker.updateProgress(time: playhead)
-            } catch TrackingError.UnableToUpdateProgress {
-                print("Tracking Error > Unable to update progress")
+                if let duration = self?.currentAdEndTime, playhead >= duration {
+                    try tracker.finishedPlayback()
+                } else {
+                    try tracker.updateProgress(time: playhead)
+                }
+            } catch TrackingError.unableToUpdateProgress(msg: let msg) {
+                print("Tracking Error > Unable to update progress: \(msg)")
             } catch {
                 print("Tracking Error > unknown")
             }
         }
     }
+}
 
-    func adBreakStart(_ id: String, _ vastModel: VastModel) {
-        print("Ad Break Started > Playhead: \(playhead), Number of Ads: \(vastModel.ads.count), Duration: \(vastModel.ads.reduce(0, { acc, cur in return acc + (cur.linearCreatives.first?.duration ?? 0)}))")
+extension VastExample: VastTrackerDelegate {
+    func adBreakStart(vastTracker: VastTracker, totalAds: Int) {
+        print("Ad Break Started > Playhead: \(playhead), Number of Ads: \(totalAds)")
     }
-
-    func adStart(_ id: String, _ ad: VastAd) {
-        print("Ad Started > Playhead: \(playhead), Id: \(ad.id), Sequence Number: \(ad.sequence), Duration: \(ad.linearCreatives.first?.duration ?? -1)")
+    
+    func adStart(vastTracker: VastTracker, ad: VastAd) {
+        let duration = ad.creatives.first?.linear?.duration
+        currentAdEndTime = playhead + (duration ?? 0)
+        print("Ad Started > Playhead: \(playhead), Id: \(ad.id), Sequence Number: \(ad.sequence ?? -1), Duration: \(duration ?? -1), skipOffset: \(ad.creatives.first?.linear?.skipOffset ?? "none")")
     }
-
-    func adFirstQuatile(_ id: String, _ ad: VastAd) {
+    
+    func adFirstQuartile(vastTracker: VastTracker, ad: VastAd) {
         print("Ad First Quartile > Playhead: \(playhead), Id: \(ad.id)")
     }
-
-    func adMidpoint(_ id: String, _ ad: VastAd) {
+    
+    func adMidpoint(vastTracker: VastTracker, ad: VastAd) {
         print("Ad Midpoint > Playhead: \(playhead), Id: \(ad.id)")
     }
-
-    func adThirdQuartile(_ id: String, _ ad: VastAd) {
+    
+    func adThirdQuartile(vastTracker: VastTracker, ad: VastAd) {
         print("Ad Third Quartile > Playhead: \(playhead), Id: \(ad.id)")
     }
-
-    func adComplete(_ id: String, _ ad: VastAd) {
+    
+    func adComplete(vastTracker: VastTracker, ad: VastAd) {
         print("Ad Complete > Playhead: \(playhead), Id: \(ad.id)")
     }
-
-    func adBreakComplete(_ id: String, _ vastModel: VastModel) {
+    
+    func adBreakComplete(vastTracker: VastTracker, vastModel: VastModel) {
         print("Ad Break Complete > Playhead: \(playhead), Number of Ads: \(vastModel.ads.count)")
         fakePlayheadProgressTimer?.invalidate()
         fakePlayheadProgressTimer = nil
     }
-
 } 

--- a/VastClientWrapper/VastClientWrapper/ViewController.swift
+++ b/VastClientWrapper/VastClientWrapper/ViewController.swift
@@ -11,7 +11,7 @@ import VastClient
 
 class ViewController: UIViewController {
 
-//    private let vastExample = VastExample()
-    private let vmapExample = VMAPExample()
+    private let vastExample = VastExample()
+//    private let vmapExample = VMAPExample()
 
 }


### PR DESCRIPTION
created vast 4 test model representation
remove incorrectly placed tags from full vast 4 file
remove iFrame and HTML resource from icons
fix name of tracking events types
fix parsing for adParameters, viewable impression and icon view tracking
fix time progress tracking in VastTracker when skipping ads
fix example project