### PR TITLE
NPOS-5244: Add support for parsing CompanionAds elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ status:
 |IconClicks|full||
 |IconClickThrough|full||
 |IconClickTracking|full||
-|NonLinearAds|not parsed|no sub-elemets supported|
-|CompanionAds|not parsed|no sub-elemets supported|
+|NonLinearAds|not parsed|no sub-elements supported|
+|CompanionAds|not parsed|no sub-elements supported|
 |Wrapper|full||
 |VASTAdTagURI|parsed||
 |CompanionAds|parsed||

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ status:
 |CompanionAds|not parsed|no sub-elemets supported|
 |Wrapper|full||
 |VASTAdTagURI|parsed||
+|CompanionAds|parsed||
+|Companion|parsed|all subelements parsed but CompanionClickTracking does not support `id` attribute|
 
 
 ## Getting Started

--- a/VastClient/VastClient/models/XML schema/VastAd.swift
+++ b/VastClient/VastClient/models/XML schema/VastAd.swift
@@ -71,9 +71,6 @@ public struct VastAd {
     public var surveys: [VastSurvey] = []
     
     public var wrapper: VastWrapper?
-    
-// TODO: uncomments and fix parsing for /CompanionAds
-//    public var companionAds = [VastCompanionAds]()
 }
 
 extension VastAd {

--- a/VastClient/VastClient/models/XML schema/VastAd.swift
+++ b/VastClient/VastClient/models/XML schema/VastAd.swift
@@ -61,7 +61,7 @@ public struct VastAd {
     public var pricing: VastPricing?
     public var errors: [URL] = []
     public var creatives: [VastCreative] = []
-    public var extensions = [VastExtension]()
+    public var extensions: [VastExtension] = []
     
     // Inline only
     public var adTitle: String?

--- a/VastClient/VastClient/models/XML schema/VastCompanionAds.swift
+++ b/VastClient/VastClient/models/XML schema/VastCompanionAds.swift
@@ -7,59 +7,59 @@
 //
 
 import Foundation
-// TODO: uncomments and fix parsing for /CompanionAds
-//struct CompanionAdsAttributes {
-//    static let required = "required"
-//}
-//
-//struct CompanionAdsElements {
-//    static let companionads = "CompanionAds"
-//    static let companion = "Companion"
-//}
-//
-///**
-// In VAST 3.0, the required attribute for the <CompanionAds> element provides information about which Companion creative to display
-// when multiple Companions are supplied and whether the Ad can be displayed without its Companion creative. The value for required can be one
-// of three values: all, any, none.
-// */
-//public enum CompanionsRequirement: String {
-//    /**
-//     The video player must attempt to display the contents for all <Companion> elemens provided;
-//     if all Companion creative cannot be displayed, the Ad should be disregarded and the ad server should be notified using the <Error> element.
-//     */
-//    case all = "all"
-//    /**
-//     The video player must attempt to display content from at least one of the <Companion> elements provided
-//     (i.e. display the one with dimensions that best fit the page); if none of the Companion creative can be displayed, the Ad should be disregarded
-//     and the ad server should be notified using the <Error> element.
-//     */
-//    case any = "any"
-//    /**
-//     The video player may choose to not display any of the Companion creative, but is not restricted from doing so; The ad server may
-//     use this option when the advertiser prefers that the master ad be displayed with or without the Companion creative.
-//     */
-//    case none = "none"
-//}
-//
-//
-//public struct VastCompanionAds {
-//    public let required: CompanionsRequirement
-//    public var companions = [VastCompanionCreative]()
-//}
-//
-//extension VastCompanionAds {
-//    public init(attrDict: [String: String]) {
-//        var required: CompanionsRequirement = .none
-//
-//        for (key, value) in attrDict {
-//            switch key {
-//            case CompanionAdsAttributes.required:
-//                required = CompanionsRequirement(rawValue: value) ?? .none
-//            default:
-//                break
-//            }
-//        }
-//
-//        self.required = required
-//    }
-//}
+
+struct CompanionAdsAttributes {
+    static let required = "required"
+}
+
+struct CompanionAdsElements {
+    static let companion = "Companion"
+}
+
+/**
+ In VAST 3.0, the required attribute for the <CompanionAds> element provides information about which Companion creative to display
+ when multiple Companions are supplied and whether the Ad can be displayed without its Companion creative. The value for required can be one
+ of three values: all, any, none.
+ */
+public enum CompanionsRequirement: String {
+    /**
+     The video player must attempt to display the contents for all <Companion> elemens provided;
+     if all Companion creative cannot be displayed, the Ad should be disregarded and the ad server should be notified using the <Error> element.
+     */
+    case all = "all"
+    /**
+     The video player must attempt to display content from at least one of the <Companion> elements provided
+     (i.e. display the one with dimensions that best fit the page); if none of the Companion creative can be displayed, the Ad should be disregarded
+     and the ad server should be notified using the <Error> element.
+     */
+    case any = "any"
+    /**
+     The video player may choose to not display any of the Companion creative, but is not restricted from doing so; The ad server may
+     use this option when the advertiser prefers that the master ad be displayed with or without the Companion creative.
+     */
+    case none = "none"
+}
+
+
+public struct VastCompanionAds {
+    public let required: CompanionsRequirement
+    public var companions: [VastCompanionCreative] = []
+}
+
+extension VastCompanionAds {
+    public init(attrDict: [String: String]) {
+        var required: CompanionsRequirement = .none
+
+        for (key, value) in attrDict {
+            switch key {
+            case CompanionAdsAttributes.required:
+                required = CompanionsRequirement(rawValue: value) ?? .none
+            default:
+                break
+            }
+        }
+
+        self.required = required
+    }
+}
+extension VastCompanionAds: Equatable {}

--- a/VastClient/VastClient/models/XML schema/VastCompanionCreative.swift
+++ b/VastClient/VastClient/models/XML schema/VastCompanionCreative.swift
@@ -28,8 +28,8 @@ struct CompanionAttributes {
     static let expandedwidth = "expandedWidth"
     static let expandedheight = "expandedHeight"
     static let apiframework = "apiFramework"
-    static let adslotid = "adSlotId"
-    static let adslotid4 = "adSlotID"
+    static let adslotid = "adSlotId" //vast 3
+    static let adslotid4 = "adSlotID" //vast 4
     static let pxRatio = "pxratio"
 }
 

--- a/VastClient/VastClient/models/XML schema/VastCompanionCreative.swift
+++ b/VastClient/VastClient/models/XML schema/VastCompanionCreative.swift
@@ -29,6 +29,12 @@ struct CompanionAttributes {
     static let expandedheight = "expandedHeight"
     static let apiframework = "apiFramework"
     static let adslotid = "adSlotId"
+    static let adslotid4 = "adSlotID"
+    static let pxRatio = "pxratio"
+}
+
+public struct VastCompanionClickTracking {
+    public let id: String?
 }
 
 public struct VastCompanionCreative {
@@ -42,6 +48,7 @@ public struct VastCompanionCreative {
     public let expandedHeight: Int?
     public let apiFramework: String?
     public let adSlotId: String?
+    public let pxRatio: Double?
     
     // Sub Elements
     public var staticResource: [VastStaticResource] = []
@@ -65,6 +72,7 @@ extension VastCompanionCreative {
         var expandedHeight: Int?
         var apiFramework: String?
         var adSlotId: String?
+        var pxRatio: Double?
 
         for (key, value) in attrDict {
             switch key {
@@ -84,8 +92,10 @@ extension VastCompanionCreative {
                 expandedHeight = Int(value)
             case CompanionAttributes.apiframework:
                 apiFramework = value
-            case CompanionAttributes.adslotid:
+            case CompanionAttributes.adslotid, CompanionAttributes.adslotid4:
                 adSlotId = value
+            case CompanionAttributes.pxRatio:
+                pxRatio = Double(value)
             default:
                 break
             }
@@ -100,6 +110,7 @@ extension VastCompanionCreative {
         self.expandedHeight = expandedHeight
         self.apiFramework = apiFramework
         self.adSlotId = adSlotId
+        self.pxRatio = pxRatio
     }
 }
 

--- a/VastClient/VastClient/models/XML schema/VastCompanionCreative.swift
+++ b/VastClient/VastClient/models/XML schema/VastCompanionCreative.swift
@@ -7,112 +7,100 @@
 //
 
 import Foundation
-// TODO: uncomments and fix parsing for /CompanionAds
-//public enum CompanionResourceType: String {
-//    /**
-//     Describes non-html creative where an attribute for creativeType is used to identify the creative resource platform.
-//     The video player uses the creativeType information to determine how to display the resource:
-//
-//     image/gif, image/jpeg, image/png: displayed using the HTML tag <img> and the resource URI as the src attribute
-//     application/x-javascript: displayed using the HTML tag <script> and the resource URI as the src attribute
-//     applicaton/x-shockwave-flash: displayed using the Flash player
-//     */
-//    case staticresource = "StaticResource"
-//    /**
-//     Describes a resouce that is a HTML page that can be displayed within an iframe on the publishers page
-//     */
-//    case iframeresource = "IFrameResource"
-//    /**
-//     Describes a "snippet" of html code to be inserted directly within the publishers HTML page code
-//     */
-//    case htmlresource = "HTMLResource"
-//    case unknown
-//}
-//
-//struct CompanionElements {
-//    static let alttext = "AltText"
-//    static let companionclickthrough = "CompanionClickThrough"
-//    static let companionclicktracking = "CompanionClickTracking"
-//    static let trackingevents = "TrackingEvents"
-//    static let adparameters = "adparameters"
-//}
-//
-//struct CompanionAttributes {
-//    static let width = "width"
-//    static let height = "height"
-//    static let id = "id"
-//    static let assetwidth = "assetWidth"
-//    static let assetheight = "assetHeight"
-//    static let expandedwidth = "expandedWidth"
-//    static let expandedheight = "expandedHeight"
-//    static let apiframework = "apiFramework"
-//    static let adslotid = "adSlotId"
-//}
-//
-//public struct VastCompanionCreative {
-//    public let width: Int
-//    public let height: Int
-//    public let id: String?
-//    public let assetWidth: Int?
-//    public let assetHeight: Int?
-//    public let expandedWidth: Int?
-//    public let expandedHeight: Int?
-//    public let apiFramework: String?
-//    public let adSlotId: String?
-//    public var type: CompanionResourceType
-//    public var content: String?
-//    public var altText: String?
-//    public var clickThrough: URL?
-//    public var clickTracking: URL?
-//    public var trackingEvents = [VastTrackingEvent]()
-//}
-//
-//extension VastCompanionCreative {
-//    public init(attrDict: [String: String]) {
-//        var width = 0
-//        var height = 0
-//        var id: String?
-//        var assetWidth: Int?
-//        var assetHeight: Int?
-//        var expandedWidth: Int?
-//        var expandedHeight: Int?
-//        var apiFramework: String?
-//        var adSlotId: String?
-//
-//        for (key, value) in attrDict {
-//            switch key {
-//            case CompanionAttributes.width:
-//                width = Int(value) ?? 0
-//            case CompanionAttributes.height:
-//                height = Int(value) ?? 0
-//            case CompanionAttributes.id:
-//                id = value
-//            case CompanionAttributes.assetwidth:
-//                assetWidth = Int(value)
-//            case CompanionAttributes.assetheight:
-//                assetHeight = Int(value)
-//            case CompanionAttributes.expandedwidth:
-//                expandedWidth = Int(value)
-//            case CompanionAttributes.expandedheight:
-//                expandedHeight = Int(value)
-//            case CompanionAttributes.apiframework:
-//                apiFramework = value
-//            case CompanionAttributes.adslotid:
-//                adSlotId = value
-//            default:
-//                break
-//            }
-//        }
-//
-//        self.width = width
-//        self.height = height
-//        self.id = id
-//        self.assetWidth = assetWidth
-//        self.assetHeight = assetHeight
-//        self.expandedWidth = expandedWidth
-//        self.expandedHeight = expandedHeight
-//        self.apiFramework = apiFramework
-//        self.adSlotId = adSlotId
-//        self.type = .unknown
-//    }
-//}
+
+struct CompanionElements {
+    static let alttext = "AltText"
+    static let companionclickthrough = "CompanionClickThrough"
+    static let companionclicktracking = "CompanionClickTracking"
+    static let trackingevents = "TrackingEvents"
+    static let adparameters = "adparameters"
+    static let htmlResource = "HTMLResource"
+    static let iframeResource = "IFrameResource"
+    static let staticResource = "StaticResource"
+}
+
+struct CompanionAttributes {
+    static let width = "width"
+    static let height = "height"
+    static let id = "id"
+    static let assetwidth = "assetWidth"
+    static let assetheight = "assetHeight"
+    static let expandedwidth = "expandedWidth"
+    static let expandedheight = "expandedHeight"
+    static let apiframework = "apiFramework"
+    static let adslotid = "adSlotId"
+}
+
+public struct VastCompanionCreative {
+    // Attributes
+    public let width: Int
+    public let height: Int
+    public let id: String?
+    public let assetWidth: Int?
+    public let assetHeight: Int?
+    public let expandedWidth: Int?
+    public let expandedHeight: Int?
+    public let apiFramework: String?
+    public let adSlotId: String?
+    
+    // Sub Elements
+    public var staticResource: [VastStaticResource] = []
+    public var iFrameResource: [URL] = []
+    public var htmlResource: [URL] = []
+    public var altText: String?
+    public var companionClickThrough: URL?
+    public var companionClickTracking: [URL] = []
+    public var trackingEvents: [VastTrackingEvent] = []
+    public var adParameters: VastAdParameters?
+}
+
+extension VastCompanionCreative {
+    public init(attrDict: [String: String]) {
+        var width = 0
+        var height = 0
+        var id: String?
+        var assetWidth: Int?
+        var assetHeight: Int?
+        var expandedWidth: Int?
+        var expandedHeight: Int?
+        var apiFramework: String?
+        var adSlotId: String?
+
+        for (key, value) in attrDict {
+            switch key {
+            case CompanionAttributes.width:
+                width = Int(value) ?? 0
+            case CompanionAttributes.height:
+                height = Int(value) ?? 0
+            case CompanionAttributes.id:
+                id = value
+            case CompanionAttributes.assetwidth:
+                assetWidth = Int(value)
+            case CompanionAttributes.assetheight:
+                assetHeight = Int(value)
+            case CompanionAttributes.expandedwidth:
+                expandedWidth = Int(value)
+            case CompanionAttributes.expandedheight:
+                expandedHeight = Int(value)
+            case CompanionAttributes.apiframework:
+                apiFramework = value
+            case CompanionAttributes.adslotid:
+                adSlotId = value
+            default:
+                break
+            }
+        }
+
+        self.width = width
+        self.height = height
+        self.id = id
+        self.assetWidth = assetWidth
+        self.assetHeight = assetHeight
+        self.expandedWidth = expandedWidth
+        self.expandedHeight = expandedHeight
+        self.apiFramework = apiFramework
+        self.adSlotId = adSlotId
+    }
+}
+
+extension VastCompanionCreative: Equatable {}

--- a/VastClient/VastClient/models/XML schema/VastCreative.swift
+++ b/VastClient/VastClient/models/XML schema/VastCreative.swift
@@ -11,6 +11,7 @@ struct VastCreativeElements {
     static let universalAdId = "UniversalAdId"
     static let linear = "Linear"
     static let creativeExtension = "CreativeExtension"
+    static let companionAds = "CompanionAds"
 }
 
 fileprivate enum VastCreativeAttribute: String, CaseIterable {
@@ -37,6 +38,7 @@ public struct VastCreative {
     public var universalAdId: VastUniversalAdId?
     public var creativeExtensions: [VastCreativeExtension] = []
     public var linear: VastLinearCreative?
+    public var companionAds: VastCompanionAds?
 }
 
 extension VastCreative {
@@ -70,5 +72,4 @@ extension VastCreative {
     }
 }
 
-extension VastCreative: Equatable {
-}
+extension VastCreative: Equatable {}

--- a/VastClient/VastClient/parsers/VastParser.swift
+++ b/VastClient/VastClient/parsers/VastParser.swift
@@ -110,16 +110,20 @@ class VastParser {
                     for (idx, creative) in copiedCreatives.enumerated() {
                         var creative = creative
                         if idx < wrapperAd.creatives.count {
-                            let wrapperLinearCreative = wrapperAd.creatives[idx]
-                            creative.linear?.duration = wrapperLinearCreative.linear?.duration
-                            if let mediaFiles = wrapperLinearCreative.linear?.mediaFiles.mediaFiles {
-                                creative.linear?.mediaFiles.mediaFiles.append(contentsOf: mediaFiles)
+                            let wrapperCreative = wrapperAd.creatives[idx]
+                            
+                            // Copy values from previous wrappers
+                            if let linear = wrapperCreative.linear {
+                                creative.linear?.duration = linear.duration
+                                creative.linear?.mediaFiles.mediaFiles.append(contentsOf: linear.mediaFiles.mediaFiles)
+                                creative.linear?.mediaFiles.interactiveCreativeFile.append(contentsOf: linear.mediaFiles.interactiveCreativeFile)
+                                creative.linear?.trackingEvents.append(contentsOf: linear.trackingEvents)
+                                creative.linear?.icons.append(contentsOf: linear.icons)
+                                creative.linear?.videoClicks.append(contentsOf: linear.videoClicks)
                             }
-                            if let interactiveFiles = wrapperLinearCreative.linear?.mediaFiles.interactiveCreativeFile {
-                                creative.linear?.mediaFiles.interactiveCreativeFile.append(contentsOf: interactiveFiles)
-                            }
-                            if let events = wrapperLinearCreative.linear?.trackingEvents {
-                                creative.linear?.trackingEvents.append(contentsOf: events)
+                            
+                            if let companions = wrapperCreative.companionAds?.companions {
+                                creative.companionAds?.companions.append(contentsOf: companions)
                             }
                         }
                         copiedCreatives[idx] = creative
@@ -127,8 +131,6 @@ class VastParser {
                     
                     copiedAd.creatives = copiedCreatives
                     copiedAd.extensions.append(contentsOf: wrapperAd.extensions)
-                    // TODO: uncomments and fix parsing for /CompanionAds
-                    //                    copiedAd.companionAds.append(contentsOf: wrapperAd.companionAds)
                 }
             } catch {
                 print("Unable to unwrap wrapper")

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -51,8 +51,8 @@ class VastXMLParser: NSObject {
     var currentVastExtension: VastExtension?
 
     // TODO: uncomments and fix parsing for /CompanionAds
-//    var creativeParameters = [VastCreativeParameter]()
-//    var currentCreativeParameter: VastCreativeParameter?
+    var creativeParameters = [VastCreativeParameter]()
+    var currentCreativeParameter: VastCreativeParameter?
 //    var currentCompanionAds: VastCompanionAds?
 //    var companions = [VastCompanionCreative]()
 //    var currentCompanionCreative: VastCompanionCreative?
@@ -159,8 +159,8 @@ extension VastXMLParser: XMLParserDelegate {
             case IconClicksElements.iconClickTracking:
                 currentIconClickTracking = VastIconClickTracking(attrDict: attributeDict)
 // TODO: uncomments and fix parsing for /CompanionAds
-//            case ExtensionElements.creativeparameter:
-//                currentCreativeParameter = VastCreativeParameter(attrDict: attributeDict)
+            case ExtensionElements.creativeparameter:
+                currentCreativeParameter = VastCreativeParameter(attrDict: attributeDict)
 //            case CompanionAdsElements.companionads:
 //                currentCompanionAds = VastCompanionAds(attrDict: attributeDict)
 //            case CompanionAdsElements.companion:
@@ -377,25 +377,17 @@ extension VastXMLParser: XMLParserDelegate {
                     currentIcon?.iconClicks?.iconClickTracking.append(currentIconClickTracking)
                 }
                 currentIconClickTracking = nil
-                
+            // TODO: external parameter - this needs to be defined outside the library
+            case ExtensionElements.creativeparameter:
+                currentCreativeParameter?.content = currentContent
+                if let creative = currentCreativeParameter {
+                    creativeParameters.append(creative)
+                    currentCreativeParameter = nil
+                }
+            case ExtensionElements.creativeparameters:
+                currentVastExtension?.creativeParameters = creativeParameters
+                creativeParameters = [VastCreativeParameter]()
 // TODO: uncomments and fix parsing for /CompanionAds
-//            case ExtensionElements.creativeparameter:
-//                currentCreativeParameter?.content = currentContent
-//                if let creative = currentCreativeParameter {
-//                    creativeParameters.append(creative)
-//                    currentCreativeParameter = nil
-//                }
-//            case ExtensionElements.creativeparameters:
-//                currentVastExtension?.creativeParameters = creativeParameters
-//                creativeParameters = [VastCreativeParameter]()
-//            case ExtensionElements.ext:
-//                if let ext = currentVastExtension {
-//                    vastExtensions.append(ext)
-//                    currentVastExtension = nil
-//                }
-//            case AdElements.extensions:
-//                currentVastAd?.extensions = vastExtensions
-//                vastExtensions = [VastExtension]()
 //            case CompanionResourceType.htmlresource.rawValue, CompanionResourceType.iframeresource.rawValue, CompanionResourceType.staticresource.rawValue:
 //                currentCompanionCreative?.type = CompanionResourceType(rawValue: elementName) ?? .unknown
 //                currentCompanionCreative?.content = currentContent

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -53,9 +53,9 @@ class VastXMLParser: NSObject {
     // TODO: uncomments and fix parsing for /CompanionAds
     var creativeParameters = [VastCreativeParameter]()
     var currentCreativeParameter: VastCreativeParameter?
-//    var currentCompanionAds: VastCompanionAds?
-//    var companions = [VastCompanionCreative]()
-//    var currentCompanionCreative: VastCompanionCreative?
+    
+    var currentCompanionAds: VastCompanionAds?
+    var currentCompanionCreative: VastCompanionCreative?
 
     var currentContent = ""
     
@@ -158,13 +158,12 @@ extension VastXMLParser: XMLParserDelegate {
                 currentIcon?.iconClicks = IconClicks()
             case IconClicksElements.iconClickTracking:
                 currentIconClickTracking = VastIconClickTracking(attrDict: attributeDict)
-// TODO: uncomments and fix parsing for /CompanionAds
             case ExtensionElements.creativeparameter:
                 currentCreativeParameter = VastCreativeParameter(attrDict: attributeDict)
-//            case CompanionAdsElements.companionads:
-//                currentCompanionAds = VastCompanionAds(attrDict: attributeDict)
-//            case CompanionAdsElements.companion:
-//                currentCompanionCreative = VastCompanionCreative(attrDict: attributeDict)
+            case VastCreativeElements.companionAds:
+                currentCompanionAds = VastCompanionAds(attrDict: attributeDict)
+            case CompanionAdsElements.companion:
+                currentCompanionCreative = VastCompanionCreative(attrDict: attributeDict)
             default:
                 break
             }

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -49,12 +49,10 @@ class VastXMLParser: NSObject {
     var currentStaticResource: VastStaticResource?
     var currentIconClickTracking: VastIconClickTracking?
     var currentVastExtension: VastExtension?
-
-    // TODO: uncomments and fix parsing for /CompanionAds
+    var currentAdParameters: VastAdParameters?
     var creativeParameters = [VastCreativeParameter]()
     var currentCreativeParameter: VastCreativeParameter?
     
-    var currentCompanionAds: VastCompanionAds?
     var currentCompanionCreative: VastCompanionCreative?
 
     var currentContent = ""
@@ -144,8 +142,8 @@ extension VastXMLParser: XMLParserDelegate {
             case CreativeLinearElements.clickthrough, CreativeLinearElements.clicktracking, CreativeLinearElements.customclick:
                 guard let type = ClickType(rawValue: elementName) else { break }
                 currentVideoClick = VastVideoClick(type: type, attrDict: attributeDict)
-            case CreativeLinearElements.adParameters:
-                currentLinearCreative?.adParameters = VastAdParameters(attrDict: attributeDict)
+            case CreativeLinearElements.adParameters, CompanionElements.adparameters:
+                currentAdParameters = VastAdParameters(attrDict: attributeDict)
             case CreativeLinearElements.mediafile:
                 currentMediaFile = VastMediaFile(attrDict: attributeDict)
             case CreativeLinearElements.interactiveCreativeFile:
@@ -161,7 +159,7 @@ extension VastXMLParser: XMLParserDelegate {
             case ExtensionElements.creativeparameter:
                 currentCreativeParameter = VastCreativeParameter(attrDict: attributeDict)
             case VastCreativeElements.companionAds:
-                currentCompanionAds = VastCompanionAds(attrDict: attributeDict)
+                currentCreative?.companionAds = VastCompanionAds(attrDict: attributeDict)
             case CompanionAdsElements.companion:
                 currentCompanionCreative = VastCompanionCreative(attrDict: attributeDict)
             default:
@@ -323,11 +321,19 @@ extension VastXMLParser: XMLParserDelegate {
                     currentCreative?.linear = linear
                     currentLinearCreative = nil
                 }
-                
             case CreativeLinearElements.duration:
                 currentLinearCreative?.duration = currentContent.toSeconds ?? -1.0
-            case CreativeLinearElements.adParameters:
-                currentLinearCreative?.adParameters?.content = currentContent // TODO this might be XML encoded content that will need better parsing
+            case CreativeLinearElements.adParameters, CompanionElements.adparameters:
+                // TODO this might be XML encoded content that will need better parsing
+                currentAdParameters?.content = currentContent
+                if let adParameters = currentAdParameters {
+                    if currentCompanionCreative != nil {
+                        currentCompanionCreative?.adParameters = adParameters
+                    } else {
+                        currentLinearCreative?.adParameters = adParameters
+                    }
+                }
+                currentAdParameters = nil
             case CreativeLinearElements.mediafile:
                 currentMediaFile?.url = URL(string: currentContent)
                 if let mediaFile = currentMediaFile {
@@ -346,10 +352,14 @@ extension VastXMLParser: XMLParserDelegate {
                     currentLinearCreative?.videoClicks.append(click)
                     currentVideoClick = nil
                 }
-            case CreativeLinearElements.tracking:
+            case CreativeLinearElements.tracking, CompanionElements.trackingevents:
                 currentTrackingEvent?.url = URL(string: currentContent)
                 if let trackingEvent = currentTrackingEvent {
-                    currentLinearCreative?.trackingEvents.append(trackingEvent)
+                    if currentCompanionCreative != nil {
+                        currentCompanionCreative?.trackingEvents.append(trackingEvent)
+                    } else {
+                        currentLinearCreative?.trackingEvents.append(trackingEvent)
+                    }
                     currentTrackingEvent = nil
                 }
             case CreativeLinearElements.icon:
@@ -358,12 +368,25 @@ extension VastXMLParser: XMLParserDelegate {
                     
                 }
                 currentIcon = nil
-            case VastIconElements.staticResource:
+            case VastIconElements.staticResource, CompanionElements.staticResource:
                 currentStaticResource?.url = URL(string: currentContent)
+                
                 if let staticResource = currentStaticResource {
-                    currentIcon?.staticResource.append(staticResource)
+                    if currentCompanionCreative != nil {
+                        currentCompanionCreative?.staticResource.append(staticResource)
+                    } else {
+                        currentIcon?.staticResource.append(staticResource)
+                    }
                 }
                 currentStaticResource = nil
+            case CompanionElements.iframeResource: // TODO: add icon iFrameResource check if necessary
+                if let url = URL(string: currentContent) {
+                    currentCompanionCreative?.iFrameResource.append(url)
+                }
+            case CompanionElements.htmlResource: // TODO: add icon htmlResource check if necessary
+                if let url = URL(string: currentContent) {
+                    currentCompanionCreative?.htmlResource.append(url)
+                }
             case VastIconElements.iconViewTracking:
                 if let url = URL(string: currentContent) {
                     currentIcon?.iconViewTracking.append(url)
@@ -376,6 +399,19 @@ extension VastXMLParser: XMLParserDelegate {
                     currentIcon?.iconClicks?.iconClickTracking.append(currentIconClickTracking)
                 }
                 currentIconClickTracking = nil
+            case CompanionAdsElements.companion:
+                if let companion = currentCompanionCreative {
+                    currentCreative?.companionAds?.companions.append(companion)
+                    currentCompanionCreative = nil
+                }
+            case CompanionElements.alttext:
+                currentCompanionCreative?.altText = currentContent
+            case CompanionElements.companionclickthrough:
+                currentCompanionCreative?.companionClickThrough = URL(string: currentContent)
+            case CompanionElements.companionclicktracking:
+                if let url = URL(string: currentContent) {
+                    currentCompanionCreative?.companionClickTracking.append(url)
+                }
             // TODO: external parameter - this needs to be defined outside the library
             case ExtensionElements.creativeparameter:
                 currentCreativeParameter?.content = currentContent
@@ -386,28 +422,6 @@ extension VastXMLParser: XMLParserDelegate {
             case ExtensionElements.creativeparameters:
                 currentVastExtension?.creativeParameters = creativeParameters
                 creativeParameters = [VastCreativeParameter]()
-// TODO: uncomments and fix parsing for /CompanionAds
-//            case CompanionResourceType.htmlresource.rawValue, CompanionResourceType.iframeresource.rawValue, CompanionResourceType.staticresource.rawValue:
-//                currentCompanionCreative?.type = CompanionResourceType(rawValue: elementName) ?? .unknown
-//                currentCompanionCreative?.content = currentContent
-//            case CompanionAdsElements.companion:
-//                if let companion = currentCompanionCreative {
-//                    companions.append(companion)
-//                    currentCompanionCreative = nil
-//                }
-//            case CompanionElements.alttext:
-//                currentCompanionCreative?.altText = currentContent
-//            case CompanionElements.companionclickthrough:
-//                currentCompanionCreative?.clickThrough = URL(string: currentContent)
-//            case CompanionElements.companionclicktracking:
-//                currentCompanionCreative?.clickTracking = URL(string: currentContent)
-//            case CompanionAdsElements.companionads:
-//                currentCompanionAds?.companions = companions
-//                companions = [VastCompanionCreative]()
-//                if let companionAds = currentCompanionAds {
-//                    currentVastAd?.companionAds.append(companionAds)
-//                    currentCompanionAds = nil
-//                }
             default:
                 break
             }

--- a/VastClient/VastClientTests/Assets/Vast3/EventTracking-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/EventTracking-test3.swift
@@ -37,7 +37,7 @@ extension VastModel {
         let icons: [VastIcon] = []
         
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
-        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: []),

--- a/VastClient/VastClientTests/Assets/Vast3/InlineLinearTag-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/InlineLinearTag-test3.swift
@@ -38,7 +38,7 @@ extension VastModel {
         let icons: [VastIcon] = []
         
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
-        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: []),

--- a/VastClient/VastClientTests/Assets/Vast3/VideoClicksAndClickTrackingInline-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/VideoClicksAndClickTrackingInline-test3.swift
@@ -39,7 +39,7 @@ extension VastModel {
         let icons: [VastIcon] = []
         
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
-        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: []),

--- a/VastClient/VastClientTests/Assets/Vast3/WrapperTag-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/WrapperTag-test3.swift
@@ -20,10 +20,12 @@ extension VastModel {
         let mediaFiles: [VastMediaFile] = []
         let interactiveMediaFiles: [VastInteractiveCreativeFile] = []
         let icons: [VastIcon] = []
-        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: nil, companionAds: nil)
+        
+        let companion1 = VastCompanionCreative(width: 100, height: 150, id: "1232", assetWidth: 250, assetHeight: 200, expandedWidth: 350, expandedHeight: 250, apiFramework: nil, adSlotId: nil, pxRatio: nil, staticResource: [VastStaticResource(creativeType: "image/png", url: URL(string: "https://www.iab.com/wp-content/uploads/2014/09/iab-tech-lab-6-644x290.png"))], iFrameResource: [], htmlResource: [], altText: nil, companionClickThrough: URL(string: "https://iabtechlab.com"), companionClickTracking: [], trackingEvents: [], adParameters: nil)
+        let companionAds = VastCompanionAds(required: .none, companions: [companion1])
+        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: nil, companionAds: companionAds)
         let extensions: [VastExtension] = []
         let adTagUri = URL(string: "https://raw.githubusercontent.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%203.0%20Samples/Inline_Companion_Tag-test.xml")!
-        // TODO: add companionAds from the file
         
         let wrapper = VastWrapper(followAdditionalWrappers: nil, allowMultipleAds: nil, fallbackOnNoAd: nil, adTagUri: adTagUri)
         

--- a/VastClient/VastClientTests/Assets/Vast3/WrapperTag-test3.swift
+++ b/VastClient/VastClientTests/Assets/Vast3/WrapperTag-test3.swift
@@ -20,7 +20,7 @@ extension VastModel {
         let mediaFiles: [VastMediaFile] = []
         let interactiveMediaFiles: [VastInteractiveCreativeFile] = []
         let icons: [VastIcon] = []
-        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: nil)
+        let creative = VastCreative(id: "5480", adId: nil, sequence: 1, apiFramework: nil, universalAdId: nil, creativeExtensions: [], linear: nil, companionAds: nil)
         let extensions: [VastExtension] = []
         let adTagUri = URL(string: "https://raw.githubusercontent.com/InteractiveAdvertisingBureau/VAST_Samples/master/VAST%203.0%20Samples/Inline_Companion_Tag-test.xml")!
         // TODO: add companionAds from the file

--- a/VastClient/VastClientTests/Assets/Vast4/AdVerification-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/AdVerification-test.swift
@@ -44,7 +44,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/Category-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/Category-test.swift
@@ -46,7 +46,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = []
         

--- a/VastClient/VastClientTests/Assets/Vast4/EventTracking-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/EventTracking-test.swift
@@ -42,7 +42,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
@@ -75,7 +75,7 @@ extension VastModel {
             tracking(hour: 1, minute: 1, second: 2, type: .firstQuartile, url: "http://example.com/track/firstQuartile1"),
             tracking(hour: 1, minute: 1, second: 3, type: .midpoint, url: "http://example.com/track/midpoint1"),
             tracking(hour: 1, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile1"),
-            tracking(hour: 1, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete1"),
+            tracking(hour: 1, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete1")
         ]
         let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking3")!, URL(string: "http://example.com/track/IconViewTracking4")!]
         let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough1"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId3", url: URL(string: "http://example.com/track/IconClickTracking3")), VastIconClickTracking(id: "IconClickTrackingId4", url: URL(string: "http://example.com/track/IconClickTracking4"))])
@@ -88,7 +88,46 @@ extension VastModel {
         let icons: [VastIcon] = [VastIcon(program: "program", width: 11, height: 10, xPosition: "20", yPosition: "21", duration: 5, offset: 6, apiFramework: "IconApiFramework1", pxratio: 1.1, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource)]
         let firstLinear = VastLinearCreative(skipOffset: "00:00:10", duration: nil, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
         
-        let firstCreative = VastCreative(id: "CreativeId1", adId: "CreativeAdId1", sequence: 1, apiFramework: "CreativeApiFramework1", universalAdId: nil, creativeExtensions: [], linear: firstLinear, companionAds: nil)
+        
+        let companion1staticResources: [VastStaticResource] = [
+            VastStaticResource(creativeType: "StaticResourceCreativeType1", url: URL(string: "http://example.com/StaticResource1")),
+            VastStaticResource(creativeType: "StaticResourceCreativeType2", url: URL(string: "http://example.com/StaticResource2"))]
+        let companion1iFrameResources: [URL] = [URL(string: "http://example.com/IFrameResource1")!, URL(string: "http://example.com/IFrameResource2")!]
+        let companion1htmlResources: [URL] = [URL(string: "http://example.com/HTMLResource1")!, URL(string: "http://example.com/HTMLResource2")!]
+        let companion1trackingEvents: [VastTrackingEvent] = [
+            tracking(hour: 0, minute: 0, second: 1, type: .mute, url: "http://example.com/track/mute"),
+            tracking(hour: 0, minute: 0, second: 2, type: .unmute, url: "http://example.com/track/unmute"),
+            tracking(hour: 0, minute: 0, second: 3, type: .pause, url: "http://example.com/track/pause"),
+            tracking(hour: 0, minute: 0, second: 4, type: .resume, url: "http://example.com/track/resume"),
+            tracking(hour: 0, minute: 0, second: 5, type: .rewind, url: "http://example.com/track/rewind"),
+            tracking(hour: 0, minute: 0, second: 6, type: .skip, url: "http://example.com/track/skip"),
+            tracking(hour: 0, minute: 0, second: 7, type: .playerExpand, url: "http://example.com/track/playerExpand"),
+            tracking(hour: 0, minute: 0, second: 8, type: .playerCollapse, url: "http://example.com/track/playerCollapse"),
+            tracking(hour: 0, minute: 0, second: 9, type: .acceptInvitationLinear, url: "http://example.com/track/acceptInvitationLinear"),
+            tracking(hour: 0, minute: 0, second: 10, type: .unknown, url: "http://example.com/track/timeSpentViewing"),
+            tracking(hour: 0, minute: 0, second: 11, type: .progress, url: "http://example.com/track/progress"),
+            tracking(hour: 0, minute: 0, second: 12, type: .creativeView, url: "http://example.com/track/creativeView"),
+            tracking(hour: 0, minute: 0, second: 13, type: .unknown, url: "http://example.com/track/acceptInvitation"),
+            tracking(hour: 0, minute: 0, second: 14, type: .unknown, url: "http://example.com/track/adExpand"),
+            tracking(hour: 0, minute: 0, second: 15, type: .unknown, url: "http://example.com/track/adCollapse"),
+            tracking(hour: 0, minute: 0, second: 16, type: .unknown, url: "http://example.com/track/minimize"),
+            tracking(hour: 0, minute: 0, second: 17, type: .unknown, url: "http://example.com/track/close"),
+            tracking(hour: 0, minute: 0, second: 18, type: .unknown, url: "http://example.com/track/overlayViewDuration"),
+            tracking(hour: 0, minute: 0, second: 19, type: .unknown, url: "http://example.com/track/otherAdInteraction"),
+            tracking(hour: 0, minute: 1, second: 1, type: .start, url: "http://example.com/track/start"),
+            tracking(hour: 0, minute: 1, second: 2, type: .firstQuartile, url: "http://example.com/track/firstQuartile"),
+            tracking(hour: 0, minute: 1, second: 3, type: .midpoint, url: "http://example.com/track/midpoint"),
+            tracking(hour: 0, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile"),
+            tracking(hour: 0, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete")
+            ]
+        let companion1adParameters = VastAdParameters(xmlEncoded: "true", content: "http://example.com/AdParameters1")
+        
+        let companion1 = VastCompanionCreative(width: 200, height: 50, id: "CompanionId1", assetWidth: 201, assetHeight: 51, expandedWidth: 202, expandedHeight: 52, apiFramework: "CompanionApiFramework1", adSlotId: "AdSlot1", pxRatio: 1, staticResource: companion1staticResources, iFrameResource: companion1iFrameResources, htmlResource: companion1htmlResources, altText: "AltText1", companionClickThrough: URL(string: "http://example.com/track/CompanionClickThrough1"), companionClickTracking: [URL(string: "http://example.com/track/CompanionClickTracking1")!, URL(string: "http://example.com/track/CompanionClickTracking2")!], trackingEvents: companion1trackingEvents, adParameters: companion1adParameters)
+        
+        let companion2 = VastCompanionCreative(width: 55, height: 205, id: "CompanionId2", assetWidth: nil, assetHeight: nil, expandedWidth: nil, expandedHeight: nil, apiFramework: nil, adSlotId: nil, pxRatio: nil, staticResource: [], iFrameResource: [], htmlResource: [], altText: nil, companionClickThrough: nil, companionClickTracking: [], trackingEvents: [], adParameters: nil)
+        let companionAds = VastCompanionAds(required: .none, companions: [companion1, companion2])
+        
+        let firstCreative = VastCreative(id: "CreativeId1", adId: "CreativeAdId1", sequence: 1, apiFramework: "CreativeApiFramework1", universalAdId: nil, creativeExtensions: [], linear: firstLinear, companionAds: companionAds)
         let secondCreative = VastCreative(id: "CreativeId2", adId: "CreativeAdId2", sequence: 2, apiFramework: "CreativeApiFramework2", universalAdId: nil, creativeExtensions: [], linear: nil, companionAds: nil)
         
         let creatives: [VastCreative] = [firstCreative ,secondCreative]
@@ -167,8 +206,8 @@ extension VastModel {
             tracking(hour: 4, minute: 1, second: 2, type: .firstQuartile, url: "http://example.com/track/firstQuartile4"),
             tracking(hour: 4, minute: 1, second: 3, type: .midpoint, url: "http://example.com/track/midpoint4"),
             tracking(hour: 4, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile4"),
-            tracking(hour: 4, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete4"),
-            ]
+            tracking(hour: 4, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete4")
+        ]
         let iconViewTracking: [URL] = [URL(string: "http://example.com/track/IconViewTracking5")!, URL(string: "http://example.com/track/IconViewTracking6")!]
         let iconClicks: IconClicks? = IconClicks(iconClickThrough: URL(string: "http://example.com/track/IconClickThrough2"), iconClickTracking: [VastIconClickTracking(id: "IconClickTrackingId5", url: URL(string: "http://example.com/track/IconClickTracking5")), VastIconClickTracking(id: "IconClickTrackingId6", url: URL(string: "http://example.com/track/IconClickTracking6"))])
         let staticResource: [VastStaticResource] = [VastStaticResource(creativeType: "StaticResourceCreativeType7", url: URL(string: "http://example.com/StaticResource7")!), VastStaticResource(creativeType: "StaticResourceCreativeType8", url: URL(string: "http://example.com/StaticResource8"))]
@@ -189,7 +228,45 @@ extension VastModel {
         
         let creativeExtensions: [VastCreativeExtension] = [VastCreativeExtension(mimeType: "CreativeExtensionType5", content: ""), VastCreativeExtension(mimeType: "CreativeExtensionType6", content: "")]
         
-        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId1"), creativeExtensions: creativeExtensions, linear: nil, companionAds: nil)
+        let companion1staticResources: [VastStaticResource] = [
+            VastStaticResource(creativeType: "StaticResourceCreativeType5", url: URL(string: "http://example.com/StaticResource5")),
+            VastStaticResource(creativeType: "StaticResourceCreativeType6", url: URL(string: "http://example.com/StaticResource6"))]
+        let companion1iFrameResources: [URL] = [URL(string: "http://example.com/IFrameResource5")!, URL(string: "http://example.com/IFrameResource6")!]
+        let companion1htmlResources: [URL] = [URL(string: "http://example.com/HTMLResource5")!, URL(string: "http://example.com/HTMLResource6")!]
+        let companion1trackingEvents: [VastTrackingEvent] = [
+            tracking(hour: 3, minute: 0, second: 1, type: .mute, url: "http://example.com/track/mute3"),
+            tracking(hour: 3, minute: 0, second: 2, type: .unmute, url: "http://example.com/track/unmute3"),
+            tracking(hour: 3, minute: 0, second: 3, type: .pause, url: "http://example.com/track/pause3"),
+            tracking(hour: 3, minute: 0, second: 4, type: .resume, url: "http://example.com/track/resume3"),
+            tracking(hour: 3, minute: 0, second: 5, type: .rewind, url: "http://example.com/track/rewind3"),
+            tracking(hour: 3, minute: 0, second: 6, type: .skip, url: "http://example.com/track/skip3"),
+            tracking(hour: 3, minute: 0, second: 7, type: .playerExpand, url: "http://example.com/track/playerExpand3"),
+            tracking(hour: 3, minute: 0, second: 8, type: .playerCollapse, url: "http://example.com/track/playerCollapse3"),
+            tracking(hour: 3, minute: 0, second: 9, type: .acceptInvitationLinear, url: "http://example.com/track/acceptInvitationLinear3"),
+            tracking(hour: 3, minute: 0, second: 10, type: .unknown, url: "http://example.com/track/timeSpentViewing3"),
+            tracking(hour: 3, minute: 0, second: 11, type: .progress, url: "http://example.com/track/progress3"),
+            tracking(hour: 3, minute: 0, second: 12, type: .creativeView, url: "http://example.com/track/creativeView3"),
+            tracking(hour: 3, minute: 0, second: 13, type: .unknown, url: "http://example.com/track/acceptInvitation3"),
+            tracking(hour: 3, minute: 0, second: 14, type: .unknown, url: "http://example.com/track/adExpand3"),
+            tracking(hour: 3, minute: 0, second: 15, type: .unknown, url: "http://example.com/track/adCollapse3"),
+            tracking(hour: 3, minute: 0, second: 16, type: .unknown, url: "http://example.com/track/minimize3"),
+            tracking(hour: 3, minute: 0, second: 17, type: .unknown, url: "http://example.com/track/close3"),
+            tracking(hour: 3, minute: 0, second: 18, type: .unknown, url: "http://example.com/track/overlayViewDuration3"),
+            tracking(hour: 3, minute: 0, second: 19, type: .unknown, url: "http://example.com/track/otherAdInteraction3"),
+            tracking(hour: 3, minute: 1, second: 1, type: .start, url: "http://example.com/track/start3"),
+            tracking(hour: 3, minute: 1, second: 2, type: .firstQuartile, url: "http://example.com/track/firstQuartile3"),
+            tracking(hour: 3, minute: 1, second: 3, type: .midpoint, url: "http://example.com/track/midpoint3"),
+            tracking(hour: 3, minute: 1, second: 4, type: .thirdQuartile, url: "http://example.com/track/thirdQuartile3"),
+            tracking(hour: 3, minute: 1, second: 5, type: .complete, url: "http://example.com/track/complete3"),
+        ]
+        let companion1adParameters = VastAdParameters(xmlEncoded: "true", content: "http://example.com/AdParameters2")
+        
+        let companion1 = VastCompanionCreative(width: 3200, height: 350, id: "CompanionId3", assetWidth: 3201, assetHeight: 351, expandedWidth: 3202, expandedHeight: 352, apiFramework: "CompanionApiFramework3", adSlotId: "AdSlot3", pxRatio: 1.3, staticResource: companion1staticResources, iFrameResource: companion1iFrameResources, htmlResource: companion1htmlResources, altText: "AltText2", companionClickThrough: URL(string: "http://example.com/track/CompanionClickThrough2"), companionClickTracking: [URL(string: "http://example.com/track/CompanionClickTracking3")!, URL(string: "http://example.com/track/CompanionClickTracking4")!], trackingEvents: companion1trackingEvents, adParameters: companion1adParameters)
+        
+        let companion2 = VastCompanionCreative(width: 455, height: 4205, id: "CompanionId4", assetWidth: nil, assetHeight: nil, expandedWidth: nil, expandedHeight: nil, apiFramework: nil, adSlotId: nil, pxRatio: nil, staticResource: [], iFrameResource: [], htmlResource: [], altText: nil, companionClickThrough: nil, companionClickTracking: [], trackingEvents: [], adParameters: nil)
+        let companionAds = VastCompanionAds(required: .any, companions: [companion1, companion2])
+        
+        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId1"), creativeExtensions: creativeExtensions, linear: nil, companionAds: companionAds)
         let secondCreative = VastCreative(id: "CreativeId4", adId: "CreativeAdId4", sequence: 4, apiFramework: "CreativeApiFramework4", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId2"), creativeExtensions: [], linear: firstLinear, companionAds: nil)
         
         let creatives: [VastCreative] = [firstCreative ,secondCreative]

--- a/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/FullVast4-test.swift
@@ -88,8 +88,8 @@ extension VastModel {
         let icons: [VastIcon] = [VastIcon(program: "program", width: 11, height: 10, xPosition: "20", yPosition: "21", duration: 5, offset: 6, apiFramework: "IconApiFramework1", pxratio: 1.1, iconViewTracking: iconViewTracking, iconClicks: iconClicks, staticResource: staticResource)]
         let firstLinear = VastLinearCreative(skipOffset: "00:00:10", duration: nil, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
         
-        let firstCreative = VastCreative(id: "CreativeId1", adId: "CreativeAdId1", sequence: 1, apiFramework: "CreativeApiFramework1", universalAdId: nil, creativeExtensions: [], linear: firstLinear)
-        let secondCreative = VastCreative(id: "CreativeId2", adId: "CreativeAdId2", sequence: 2, apiFramework: "CreativeApiFramework2", universalAdId: nil, creativeExtensions: [], linear: nil)
+        let firstCreative = VastCreative(id: "CreativeId1", adId: "CreativeAdId1", sequence: 1, apiFramework: "CreativeApiFramework1", universalAdId: nil, creativeExtensions: [], linear: firstLinear, companionAds: nil)
+        let secondCreative = VastCreative(id: "CreativeId2", adId: "CreativeAdId2", sequence: 2, apiFramework: "CreativeApiFramework2", universalAdId: nil, creativeExtensions: [], linear: nil, companionAds: nil)
         
         let creatives: [VastCreative] = [firstCreative ,secondCreative]
         let extensions: [VastExtension] = [VastExtension(type: "ExtensionType1", creativeParameters: []), VastExtension(type: "ExtensionType2", creativeParameters: [])]
@@ -189,8 +189,8 @@ extension VastModel {
         
         let creativeExtensions: [VastCreativeExtension] = [VastCreativeExtension(mimeType: "CreativeExtensionType5", content: ""), VastCreativeExtension(mimeType: "CreativeExtensionType6", content: "")]
         
-        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId1"), creativeExtensions: creativeExtensions, linear: nil)
-        let secondCreative = VastCreative(id: "CreativeId4", adId: "CreativeAdId4", sequence: 4, apiFramework: "CreativeApiFramework4", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId2"), creativeExtensions: [], linear: firstLinear)
+        let firstCreative = VastCreative(id: "CreativeId3", adId: "CreativeAdId3", sequence: 3, apiFramework: "CreativeApiFramework3", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId1"), creativeExtensions: creativeExtensions, linear: nil, companionAds: nil)
+        let secondCreative = VastCreative(id: "CreativeId4", adId: "CreativeAdId4", sequence: 4, apiFramework: "CreativeApiFramework4", universalAdId: VastUniversalAdId(idRegistry: "unknown", idValue: "unknown", uniqueCreativeId: "UniversalAdId2"), creativeExtensions: [], linear: firstLinear, companionAds: nil)
         
         let creatives: [VastCreative] = [firstCreative ,secondCreative]
         let extensions: [VastExtension] = [VastExtension(type: "ExtensionType3", creativeParameters: []), VastExtension(type: "ExtensionType4", creativeParameters: [])]

--- a/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineLinearIcons-test.swift
@@ -47,7 +47,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/InlineLinearTag-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineLinearTag-test.swift
@@ -42,7 +42,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/InlineSimple-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/InlineSimple-test.swift
@@ -44,7 +44,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = []
         

--- a/VastClient/VastClientTests/Assets/Vast4/NoWrapperTag-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/NoWrapperTag-test.swift
@@ -42,7 +42,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsInlineModel-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsInlineModel-test.swift
@@ -34,7 +34,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 20, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId: VastUniversalAdId? = nil
         
-        let creative = VastCreative(id: nil, adId: "29619UQ", sequence: nil, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: nil, adId: "29619UQ", sequence: nil, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = []
         

--- a/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsModel-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsModel-test.swift
@@ -36,6 +36,9 @@ extension VastModel {
         if let trackingEvents = linear?.trackingEvents {
             model.ads[0].creatives[0].linear?.trackingEvents.append(contentsOf: trackingEvents)
         }
+        if let videoClicks = linear?.videoClicks {
+            model.ads[0].creatives[0].linear?.videoClicks.append(contentsOf: videoClicks)
+        }
         
         return model
     }()

--- a/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsWrapperModel-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/Pubads wrapper/PubadsWrapperModel-test.swift
@@ -44,7 +44,7 @@ extension VastModel {
         let linear: VastLinearCreative? = VastLinearCreative(skipOffset: nil, duration: nil, adParameters: nil, videoClicks:videoClicks, trackingEvents: trackingEvents, mediaFiles: mediaFiles, icons: icons)
         let universalAdId: VastUniversalAdId? = nil
         
-        let creative = VastCreative(id: "138249517389", adId: nil, sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "138249517389", adId: nil, sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "geo", creativeParameters: []),

--- a/VastClient/VastClientTests/Assets/Vast4/ReadyToServerMediaFilesCheck-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/ReadyToServerMediaFilesCheck-test.swift
@@ -42,7 +42,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/UniversalAdId-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/UniversalAdId-test.swift
@@ -44,7 +44,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/VideoClicksAndClickTracking-Inline-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/VideoClicksAndClickTracking-Inline-test.swift
@@ -45,7 +45,7 @@ extension VastModel {
         let linear = VastLinearCreative(skipOffset: nil, duration: 16, adParameters: nil, videoClicks: videoClicks, trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(mediaFiles: mediaFiles, interactiveCreativeFile: interactiveMediaFiles), icons: icons)
         let universalAdId = VastUniversalAdId(idRegistry: "Ad-ID", idValue: "8465", uniqueCreativeId: "8465")
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = [
             VastExtension(type: "iab-Count", creativeParameters: [])

--- a/VastClient/VastClientTests/Assets/Vast4/ViewableImpression.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/ViewableImpression.swift
@@ -26,7 +26,7 @@ extension VastModel {
         let linear: VastLinearCreative? = VastLinearCreative(skipOffset: nil, duration: nil, adParameters: nil, videoClicks: [], trackingEvents: trackingEvents, mediaFiles: VastMediaFiles(), icons: [])
         let universalAdId: VastUniversalAdId? = nil
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = []
         

--- a/VastClient/VastClientTests/Assets/Vast4/WrapperTag-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/WrapperTag-test.swift
@@ -22,7 +22,7 @@ extension VastModel {
         let linear: VastLinearCreative? = nil
         let universalAdId: VastUniversalAdId? = nil
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear)
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
         
         let extensions: [VastExtension] = []
         

--- a/VastClient/VastClientTests/Assets/Vast4/WrapperTag-test.swift
+++ b/VastClient/VastClientTests/Assets/Vast4/WrapperTag-test.swift
@@ -22,7 +22,9 @@ extension VastModel {
         let linear: VastLinearCreative? = nil
         let universalAdId: VastUniversalAdId? = nil
         
-        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: nil)
+        let companion1 = VastCompanionCreative(width: 100, height: 150, id: "1232", assetWidth: 250, assetHeight: 200, expandedWidth: 350, expandedHeight: 250, apiFramework: "VPAID", adSlotId: "3214", pxRatio: 1400, staticResource: [VastStaticResource(creativeType: "image/png", url: URL(string: "https://www.iab.com/wp-content/uploads/2014/09/iab-tech-lab-6-644x290.png"))], iFrameResource: [], htmlResource: [], altText: nil, companionClickThrough: URL(string: "https://iabtechlab.com"), companionClickTracking: [], trackingEvents: [], adParameters: nil)
+        let companionAds = VastCompanionAds(required: .none, companions: [companion1])
+        let creative = VastCreative(id: "5480", adId: "2447226", sequence: 1, apiFramework: nil, universalAdId: universalAdId, creativeExtensions: [], linear: linear, companionAds: companionAds)
         
         let extensions: [VastExtension] = []
         

--- a/VastClient/VastClientTests/VastXMLParserPubadsWrapperTests.swift
+++ b/VastClient/VastClientTests/VastXMLParserPubadsWrapperTests.swift
@@ -42,7 +42,7 @@ class VastXMLParserPubadsWrapperTests: XCTestCase {
             expect.fulfill()
         }
         
-        waitForExpectations(timeout: 15, handler: { _ in
+        waitForExpectations(timeout: 1, handler: { _ in
             XCTAssertTrue(model != nil)
             XCTAssertEqual(model, VastModel.pubadsModel)
         })


### PR DESCRIPTION
Slightly edited - not exactly as the original, but the VastModel could not be left the original way after our rework to match the VAST schema better for easier orientation for other people.

Updated flattening of wrappers slightly (only cosmetic changes) + added the companion ads there also.

Updated tests to match. 

Tests now cover 65,3% of VastClient
missing is only:
Tracker - we could - should add tests here in the future if we find tracking related bugs.
VMAP - not supported at this time